### PR TITLE
Better profile.release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,5 @@ pretty_assertions = "1.4.1"
 
 
 [profile.release]
-debug = false
+strip = "debuginfo"
+lto = "thin"


### PR DESCRIPTION
I think current development is not being done in this repo, as the only commits have been the ones made at the day of release, nonetheless these are simple enough changes that could be cherry picked within the actual developement repo (if it hasn't been adressed already).

- debug = false is not necessary, release profile already sets that by default (see: https://doc.rust-lang.org/cargo/reference/profiles.html#release)
- strip debuginfo aiming for smaller binaries
- leverage llvm's lto for (hopefully) better perf