### PR TITLE
fix: book broken links

### DIFF
--- a/psyche-book/src/enduser/authentication.md
+++ b/psyche-book/src/enduser/authentication.md
@@ -60,4 +60,4 @@ sh scripts/join-authorization-set-delegates.sh devnet $GRANTOR_PUBKEY grantee.js
 
 ## Further information
 
-The source code for the `authorizer` smart contract used by the Psyche's coordinator can be found here with its readme: <https://github.com/NousResearch/psyche/tree/main/architectures/decentralized/solana-authorizer>
+The source code for the `authorizer` smart contract used by the Psyche's coordinator can be found here with its readme: <https://github.com/PsycheFoundation/psyche/tree/main/architectures/decentralized/solana-authorizer>

--- a/psyche-book/src/explain/rewards.md
+++ b/psyche-book/src/explain/rewards.md
@@ -10,10 +10,10 @@ A Training run can be created through a `Treasurer` escrow smart contract. In th
 
 In this case, an arbitrary token can be distributed through the `Treasurer`'s Token holding. Every time a client earns a point on the run's coordinator, the treasurer will allow claiming a fixed amount of reward token for each earned coordinator point.
 
-The source code for the treasurer smart contract can be found here: <https://github.com/NousResearch/psyche/tree/main/architectures/decentralized/solana-treasurer>.
+The source code for the treasurer smart contract can be found here: <https://github.com/PsycheFoundation/psyche/tree/main/architectures/decentralized/solana-treasurer>.
 
 ## Mining Pool, Pooling funds
 
-Participating in a run can be expensive — a powerful GPU may be required to train a particular model. Users can pool resources together through a Mining Pool smart contract. The source code used can be found here: <https://github.com/NousResearch/psyche/tree/main/architectures/decentralized/solana-mining-pool>.
+Participating in a run can be expensive — a powerful GPU may be required to train a particular model. Users can pool resources together through a Mining Pool smart contract. The source code used can be found here: <https://github.com/PsycheFoundation/psyche/tree/main/architectures/decentralized/solana-mining-pool>.
 
 Each user contributing to a Mining Pool will delegate their funds so those can be used by the Mining Pool authority and owner to purchase compute power. The Mining Pool authority can then re-distribute equitably through the Mining Pool any token that may have been received as a result of the training.


### PR DESCRIPTION
Fix links to smart contracts in the `psyche-book`