### PR TITLE
fix: remove short run id arg

### DIFF
--- a/architectures/decentralized/solana-client/src/main.rs
+++ b/architectures/decentralized/solana-client/src/main.rs
@@ -118,7 +118,7 @@ enum Commands {
         #[clap(flatten)]
         wallet: WalletArgs,
 
-        #[clap(short, long, env)]
+        #[clap(long, env)]
         run_id: String,
 
         #[clap(short, long, env)]


### PR DESCRIPTION
-r was used for both run_id and resume, causing a runtime error.