### PR TITLE
nit: treasurer: remove the need for collateral_amount_per_earned_point

### DIFF
--- a/architectures/decentralized/solana-tooling/src/get_accounts.rs
+++ b/architectures/decentralized/solana-tooling/src/get_accounts.rs
@@ -2,6 +2,7 @@ use anchor_lang::AccountDeserialize;
 use psyche_solana_authorizer::state::Authorization;
 use psyche_solana_coordinator::coordinator_account_from_bytes;
 use psyche_solana_coordinator::CoordinatorInstanceState;
+use psyche_solana_treasurer::state::Participant;
 use psyche_solana_treasurer::state::Run;
 use solana_sdk::pubkey::Pubkey;
 use solana_toolbox_endpoint::ToolboxEndpoint;
@@ -63,12 +64,12 @@ pub async fn get_run(
 pub async fn get_participant(
     endpoint: &mut ToolboxEndpoint,
     participant: &Pubkey,
-) -> Result<Option<Run>, ToolboxEndpointError> {
+) -> Result<Option<Participant>, ToolboxEndpointError> {
     endpoint
         .get_account_data(participant)
         .await?
         .map(|data| {
-            Run::try_deserialize(&mut data.as_slice()).map_err(|_| {
+            Participant::try_deserialize(&mut data.as_slice()).map_err(|_| {
                 ToolboxEndpointError::Custom(
                     "Unable to decode participant data".to_string(),
                 )

--- a/architectures/decentralized/solana-tooling/tests/suites/memnet_treasurer_full_epoch.rs
+++ b/architectures/decentralized/solana-tooling/tests/suites/memnet_treasurer_full_epoch.rs
@@ -50,8 +50,8 @@ pub async fn run() {
     let participant = Keypair::new();
     let client = Keypair::new();
     let ticker = Keypair::new();
+    let rounds_per_epoch = 4;
     let earned_point_per_epoch = 33;
-    let collateral_amount_per_earned_point = 42;
 
     // Prepare the collateral mint
     let collateral_mint_authority = Keypair::new();
@@ -86,7 +86,6 @@ pub async fn run() {
             run_id: "This is my run's dummy run_id".to_string(),
             main_authority: main_authority.pubkey(),
             join_authority: join_authority.pubkey(),
-            collateral_amount_per_earned_point,
         },
     )
     .await
@@ -203,7 +202,7 @@ pub async fn run() {
                 global_batch_size_warmup_tokens: 0,
                 verification_percent: 0,
                 witness_nodes: 1,
-                rounds_per_epoch: 4,
+                rounds_per_epoch,
                 total_steps: 100,
             }),
             model: Some(Model::LLM(LLM {
@@ -310,7 +309,8 @@ pub async fn run() {
     .await
     .unwrap();
 
-    for _ in 0..4 {
+    // Go through an epoch's rounds
+    for _ in 0..rounds_per_epoch {
         // Witness
         process_coordinator_witness(
             &mut endpoint,

--- a/architectures/decentralized/solana-treasurer/programs/solana-treasurer/src/logic/participant_claim.rs
+++ b/architectures/decentralized/solana-treasurer/programs/solana-treasurer/src/logic/participant_claim.rs
@@ -89,8 +89,9 @@ pub fn participant_claim_processor(
     {
         return err!(ProgramError::InvalidParameter);
     }
-    let claim_collateral_amount =
-        params.claim_earned_points * run.collateral_amount_per_earned_point;
+
+    // We distribute 1 collateral per point and let the coordinator decide the point reward rate
+    let claim_collateral_amount = params.claim_earned_points * 1;
 
     participant.claimed_collateral_amount += claim_collateral_amount;
     participant.claimed_earned_points += params.claim_earned_points;

--- a/architectures/decentralized/solana-treasurer/programs/solana-treasurer/src/logic/participant_claim.rs
+++ b/architectures/decentralized/solana-treasurer/programs/solana-treasurer/src/logic/participant_claim.rs
@@ -91,7 +91,7 @@ pub fn participant_claim_processor(
     }
 
     // We distribute 1 collateral per point and let the coordinator decide the point reward rate
-    let claim_collateral_amount = params.claim_earned_points * 1;
+    let claim_collateral_amount = params.claim_earned_points;
 
     participant.claimed_collateral_amount += claim_collateral_amount;
     participant.claimed_earned_points += params.claim_earned_points;

--- a/architectures/decentralized/solana-treasurer/programs/solana-treasurer/src/logic/run_create.rs
+++ b/architectures/decentralized/solana-treasurer/programs/solana-treasurer/src/logic/run_create.rs
@@ -66,7 +66,6 @@ pub struct RunCreateParams {
     pub run_id: String,
     pub main_authority: Pubkey,
     pub join_authority: Pubkey,
-    pub collateral_amount_per_earned_point: u64,
 }
 
 pub fn run_create_processor(
@@ -84,8 +83,6 @@ pub fn run_create_processor(
     run.coordinator_account = context.accounts.coordinator_account.key();
 
     run.collateral_mint = context.accounts.collateral_mint.key();
-    run.collateral_amount_per_earned_point =
-        params.collateral_amount_per_earned_point;
 
     run.total_funded_collateral_amount = 0;
     run.total_claimed_collateral_amount = 0;

--- a/architectures/decentralized/solana-treasurer/programs/solana-treasurer/src/state/run.rs
+++ b/architectures/decentralized/solana-treasurer/programs/solana-treasurer/src/state/run.rs
@@ -13,7 +13,6 @@ pub struct Run {
     pub coordinator_instance: Pubkey,
 
     pub collateral_mint: Pubkey,
-    pub collateral_amount_per_earned_point: u64,
 
     pub total_funded_collateral_amount: u64,
     pub total_claimed_collateral_amount: u64,


### PR DESCRIPTION
## Summary

This is a nit to simplify the logic for the treasurer, where we used to have the coordinator set a reward rate for each epoch then the treasurer would also set a reward rate "per-point".

Then the reward would be: `collateral = point_reward * collateral_per_point`. This is unecessary as of right now as the coordinator can simply specify whatever rate it wants and the treasurer can just distribute one collateral per point.
