### PR TITLE
fix: warmup run state related bugs

### DIFF
--- a/architectures/centralized/testing/src/client.rs
+++ b/architectures/centralized/testing/src/client.rs
@@ -89,7 +89,7 @@ impl ClientHandle {
             Client::default(server_port, run_id).await;
         let client_handle =
             tokio::spawn(async move { client.run(allowlist, p2p, state_options).await });
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
         Self { client_handle }
     }
 

--- a/architectures/centralized/testing/src/test_utils.rs
+++ b/architectures/centralized/testing/src/test_utils.rs
@@ -63,7 +63,7 @@ where
     Fut: Future<Output = T>,
     F: FnMut() -> Fut,
 {
-    let retry_attempts: u64 = 500;
+    let retry_attempts: u64 = 100;
     let mut result;
     for attempt in 1..=retry_attempts {
         result = function().await;

--- a/architectures/centralized/testing/tests/integration_tests.rs
+++ b/architectures/centralized/testing/tests/integration_tests.rs
@@ -15,7 +15,7 @@ use psyche_coordinator::{
 };
 use tracing::info;
 
-#[test_log::test(tokio::test(flavor = "current_thread"))]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn connect_single_node() {
     let init_min_clients = 2;
     let global_batch_size = 4;
@@ -425,21 +425,17 @@ async fn client_join_in_training() {
     assert_with_retries(|| server_handle.get_rounds_head(), 1).await;
 
     // run through the rest of the epoch
-    info!("running through the rest of the epoch");
     assert_with_retries(|| server_handle.get_rounds_head(), 1).await;
     assert_with_retries(|| server_handle.get_rounds_head(), 2).await;
     assert_with_retries(|| server_handle.get_rounds_head(), 3).await;
 
-    info!("asserting witnesses");
     // Assert that the witness healthy score of the previous round
     // 1 witness, 2 clients and each one trained 1 batch, expected_score = 2
     assert_witnesses_healthy_score(&server_handle, 1, 2).await;
 
-    info!("asserting warmup");
     // check that the run state evolves naturally to Warmup
     assert_with_retries(|| server_handle.get_run_state(), RunState::Warmup).await;
 
-    info!("getting clients");
     // check that the clients length shows the new joined client
     assert_with_retries(|| server_handle.get_clients_len(), 3).await;
 }

--- a/architectures/centralized/testing/tests/integration_tests.rs
+++ b/architectures/centralized/testing/tests/integration_tests.rs
@@ -15,7 +15,7 @@ use psyche_coordinator::{
 };
 use tracing::info;
 
-#[test_log::test(tokio::test(flavor = "multi_thread"))]
+#[test_log::test(tokio::test(flavor = "current_thread"))]
 async fn connect_single_node() {
     let init_min_clients = 2;
     let global_batch_size = 4;
@@ -425,17 +425,21 @@ async fn client_join_in_training() {
     assert_with_retries(|| server_handle.get_rounds_head(), 1).await;
 
     // run through the rest of the epoch
+    info!("running through the rest of the epoch");
     assert_with_retries(|| server_handle.get_rounds_head(), 1).await;
     assert_with_retries(|| server_handle.get_rounds_head(), 2).await;
     assert_with_retries(|| server_handle.get_rounds_head(), 3).await;
 
+    info!("asserting witnesses");
     // Assert that the witness healthy score of the previous round
     // 1 witness, 2 clients and each one trained 1 batch, expected_score = 2
     assert_witnesses_healthy_score(&server_handle, 1, 2).await;
 
+    info!("asserting warmup");
     // check that the run state evolves naturally to Warmup
     assert_with_retries(|| server_handle.get_run_state(), RunState::Warmup).await;
 
+    info!("getting clients");
     // check that the clients length shows the new joined client
     assert_with_retries(|| server_handle.get_clients_len(), 3).await;
 }

--- a/architectures/decentralized/testing/tests/integration_tests.rs
+++ b/architectures/decentralized/testing/tests/integration_tests.rs
@@ -873,6 +873,7 @@ async fn test_solana_subscriptions() {
 
     assert_eq!(subscription_events, expected_subscription_events[3..]);
     println!("subscription_events: {subscription_events:?}");
+}
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[serial]

--- a/shared/client/src/state/steps.rs
+++ b/shared/client/src/state/steps.rs
@@ -13,7 +13,7 @@ use std::{
     collections::HashMap,
     fmt,
     sync::{Arc, Mutex},
-    time::{Instant, SystemTime, UNIX_EPOCH},
+    time::Instant,
 };
 use tch::TchError;
 use thiserror::Error;
@@ -902,7 +902,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> RunManager<T, A> {
         if let InitStage::Initializing((_init_future, init_state)) = &mut self.0 {
             // if we're still initializing, check to see if we're done
             let init_state = *init_state;
-            self.apply_state(None, init_state).await?;
+            self.apply_state(init_state).await?;
         }
         if let InitStage::Running(state_machine) = &mut self.0 {
             state_machine.try_send_opportunistic_witness()?;
@@ -946,38 +946,13 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> RunManager<T, A> {
         }
     }
 
-    pub async fn apply_state(
-        &mut self,
-        old_state: Option<Coordinator<T>>,
-        state: Coordinator<T>,
-    ) -> Result<(), ApplyStateError> {
-        if state.run_state == RunState::Warmup {
-            info!("WARMUP STATE RECEIVED");
-            if old_state.is_some() {
-                info!("OLD STATE BEING: {:?}", old_state.unwrap().run_state);
-            } else {
-                info!("OLD STATE BEING: None");
-            }
-        }
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        info!(
-            "AAAAAAAAAAAA: {}",
-            (state.run_state_start_unix_timestamp as f64 / state.config.warmup_time as f64)
-        );
+    pub async fn apply_state(&mut self, state: Coordinator<T>) -> Result<(), ApplyStateError> {
         let new_state = match &mut self.0 {
             InitStage::NotYetInitialized(init_info @ Some(..))
             // We run the initialization only when we are sure that we didn't just recently joined in Warmup
-            // If this is the case, then `old_state` is `None` and we will have to wait untill the next epoch
-                if (state.run_state == RunState::Warmup
-                    && (old_state.map(|old_state| old_state.run_state)
-                        == Some(RunState::WaitingForMembers)
-                        || old_state.map(|old_state| old_state.run_state)
-                            == Some(RunState::Cooldown))) || (state.run_state == RunState::Warmup && old_state.map(|old_state| old_state.run_state) == Some(RunState::Warmup) && ((timestamp - state.run_state_start_unix_timestamp) as f64 / state.config.warmup_time as f64) <= 0.2) =>
+            // If this is the case, then our ID won't be present in the list of clients available for this epoch
+                if state.run_state == RunState::Warmup && state.epoch_state.clients.iter().any(|c| c.id == init_info.as_ref().unwrap().init_config.identity) =>
             {
-                info!("INITIALIZING MODEL");
                 // Take ownership of init_info using std::mem::take
                 let init_info = init_info.take().unwrap();
                 Some(InitStage::Initializing((


### PR DESCRIPTION
Until now, when a client joined in Warmup, it started downloading the model either via p2p or hub, but it was not yet allowed to participate in the upcoming epoch.

Additionally, if everybody left while in Warmup, when another client joined, it would request parameters to peers that are no longer in the run.

This PR handles all these bugs. The fix is straightforward, clients that join in Warmup have to wait until the next epoch to download the model & start training