### PR TITLE
Add PIQA model evaluation

### DIFF
--- a/shared/eval/src/lib.rs
+++ b/shared/eval/src/lib.rs
@@ -6,20 +6,21 @@ mod tasks;
 mod traits;
 
 pub use harness::{EvalTaskOptions, PreparedTask, PreparedTaskResult, Task, TaskType};
-pub use tasks::{ArcChallenge, ArcEasy, BoolQ, Hellaswag, MMLUPro, MMLU};
+pub use tasks::{ArcChallenge, ArcEasy, BoolQ, Hellaswag, MMLUPro, MMLU, PIQA};
 
 pub const ASCII_UPPERCASE: [&str; 26] = [
     "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S",
     "T", "U", "V", "W", "X", "Y", "Z",
 ];
 
-pub const ALL_TASK_NAMES: [&str; 6] = [
+pub const ALL_TASK_NAMES: [&str; 7] = [
     ArcChallenge::name(),
     ArcEasy::name(),
     BoolQ::name(),
     Hellaswag::name(),
     MMLUPro::name(),
     MMLU::name(),
+    PIQA::name(),
 ];
 
 pub fn load_dataset(
@@ -52,6 +53,7 @@ pub fn tasktype_from_name(name: &str) -> Result<TaskType> {
         "hellaswag" => Hellaswag::load(),
         "mmlu_pro" => MMLUPro::load(),
         "mmlu" => MMLU::load(),
+        "piqa" => PIQA::load(),
         _ => bail!("Unknown task {name}"),
     }
 }

--- a/shared/eval/src/tasks/boolq.rs
+++ b/shared/eval/src/tasks/boolq.rs
@@ -22,7 +22,7 @@ impl BoolQ {
     }
 
     pub const fn name() -> &'static str {
-        "boolq"
+        "BoolQ"
     }
 
     fn row_to_document(dataset: &Dataset, row: Row) -> Document {

--- a/shared/eval/src/tasks/mod.rs
+++ b/shared/eval/src/tasks/mod.rs
@@ -3,6 +3,7 @@ mod boolq;
 mod hellaswag;
 mod mmlu;
 mod mmlu_pro;
+mod piqa;
 
 pub use arc::ArcChallenge;
 pub use arc::ArcEasy;
@@ -10,3 +11,4 @@ pub use boolq::BoolQ;
 pub use hellaswag::Hellaswag;
 pub use mmlu::MMLU;
 pub use mmlu_pro::MMLUPro;
+pub use piqa::PIQA;

--- a/shared/eval/src/tasks/piqa.rs
+++ b/shared/eval/src/tasks/piqa.rs
@@ -22,7 +22,7 @@ impl PIQA {
     }
 
     pub const fn name() -> &'static str {
-        "piqa"
+        "PIQA"
     }
 
     fn row_to_document(dataset: &Dataset, row: Row) -> Document {

--- a/shared/eval/src/tasks/piqa.rs
+++ b/shared/eval/src/tasks/piqa.rs
@@ -41,7 +41,7 @@ impl PIQA {
             .unwrap()
             .to_owned();
 
-        let text = format!("{}\n", goal);
+        let text = format!("Question: {goal}\nAnswer:");
         let choices = vec![sol1, sol2];
 
         let answer = row

--- a/shared/eval/src/tasks/piqa.rs
+++ b/shared/eval/src/tasks/piqa.rs
@@ -1,0 +1,79 @@
+use crate::{
+    load_dataset,
+    traits::{Document, LogLikelihoodTask},
+    TaskType,
+};
+use anyhow::Result;
+use psyche_data_provider::{Dataset, Row, RowAccessor, Split};
+use std::fmt::Display;
+
+pub struct PIQA {
+    train_dataset: Dataset,
+    validation_dataset: Dataset,
+}
+
+impl PIQA {
+    pub fn load() -> Result<TaskType> {
+        let ret = Self {
+            train_dataset: load_dataset("ybisk/piqa", None, Split::Train, None)?,
+            validation_dataset: load_dataset("ybisk/piqa", None, Split::Validation, None)?,
+        };
+        Ok(TaskType::LogLikelihood(Box::new(ret)))
+    }
+
+    pub const fn name() -> &'static str {
+        "piqa"
+    }
+
+    fn row_to_document(dataset: &Dataset, row: Row) -> Document {
+        let goal = row
+            .get_string(dataset.get_column_id("goal").unwrap())
+            .unwrap()
+            .to_owned();
+
+        let sol1 = row
+            .get_string(dataset.get_column_id("sol1").unwrap())
+            .unwrap()
+            .to_owned();
+
+        let sol2 = row
+            .get_string(dataset.get_column_id("sol2").unwrap())
+            .unwrap()
+            .to_owned();
+
+        let text = format!("{}\n", goal);
+        let choices = vec![sol1, sol2];
+
+        let answer = row
+            .get_long(dataset.get_column_id("label").unwrap())
+            .unwrap() as usize;
+
+        Document {
+            text,
+            choices,
+            answer,
+        }
+    }
+}
+
+impl LogLikelihoodTask for PIQA {
+    fn get_documents(&self) -> Vec<Document> {
+        self.validation_dataset
+            .iter()
+            .map(|row| PIQA::row_to_document(&self.validation_dataset, row))
+            .collect()
+    }
+
+    fn get_fewshot_documents(&self) -> Vec<Document> {
+        self.train_dataset
+            .iter()
+            .map(|row| PIQA::row_to_document(&self.train_dataset, row))
+            .collect()
+    }
+}
+
+impl Display for PIQA {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", Self::name())
+    }
+}


### PR DESCRIPTION
Add the PIQA benchmark to evaluate the model

* Benchmark results:
```
cargo run --release --example evaluate -- --tasks piqa --model TinyLlama/TinyLlama-1.1B-Chat-v0.1
PIQA: {"acc": 0.691512513601741, "acc_norm": 0.6953210010881393}

cargo run --release --example evaluate -- --tasks piqa --model TinyLlama/TinyLlama-1.1B-Chat-v0.4
PIQA: {"acc": 0.7105549510337323, "acc_norm": 0.7138193688792165}
```
* [Benchmark results for comparation](https://github.com/jzhang38/TinyLlama/blob/main/EVAL.md)
* [paper](https://arxiv.org/abs/1911.11641)
* [llm_eval](https://github.com/EleutherAI/lm-evaluation-harness/blob/7aaceeec2e7b686d95d0e55b43af641dc2484b4a/lm_eval/tasks/piqa/piqa.yaml)


