### PR TITLE
frontend: fix: rank table width in chromium

### DIFF
--- a/website/frontend/src/components/ContributeCompute.tsx
+++ b/website/frontend/src/components/ContributeCompute.tsx
@@ -124,6 +124,7 @@ const RankTable = styled.table`
 	left: 0;
 	right: 0;
 	bottom: 0;
+	width: 100%;
 	margin-top: 16px;
 	border-collapse: collapse;
 


### PR DESCRIPTION
firefox works fine without it, but chromium doesn't. weird!