### PR TITLE
Update idle timeout and retry configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "iroh-blobs"
 version = "0.34.0"
-source = "git+https://github.com/NousResearch/iroh-blobs?rev=64210c4d02774777e8f82e5d64f5e8d1d3d361f4#64210c4d02774777e8f82e5d64f5e8d1d3d361f4"
+source = "git+https://github.com/NousResearch/iroh-blobs?rev=f26e5a60c5b7fe32b5f2d4e590c7d55b97b346a5#f26e5a60c5b7fe32b5f2d4e590c7d55b97b346a5"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ iroh = { git = "https://github.com/NousResearch/iroh", rev = "e0b8c597b301d8f591
 iroh-relay = { git = "https://github.com/NousResearch/iroh", rev = "e0b8c597b301d8f5913e8c0ac57ec4d6d76595b3", features = [
   "metrics",
 ] }
-iroh-blobs = { git = "https://github.com/NousResearch/iroh-blobs", rev = "64210c4d02774777e8f82e5d64f5e8d1d3d361f4", features = [
+iroh-blobs = { git = "https://github.com/NousResearch/iroh-blobs", rev = "f26e5a60c5b7fe32b5f2d4e590c7d55b97b346a5", features = [
   "rpc",
   "downloader",
   "metrics",


### PR DESCRIPTION
Instead of adding blob-level timeouts in iroh, we tweaked some configuration parameters to ensure that blob downloads time out at the connection level if no progress is made. These new settings apply a 5 second idle timeout and abort each failed download attempt immediately, so we can trigger our own retry logic rather than relying on iroh’s built-in retries.
