### PR TITLE
test: new tests for network module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 members = [
-  "architectures/centralized/*",
-  "architectures/decentralized/solana-client",
-  "architectures/decentralized/testing",
-  "architectures/decentralized/solana-tooling",
-  "shared/*",
-  "tools/rust-tools/*",
-  "website/wasm",
+    "architectures/centralized/*",
+    "architectures/decentralized/solana-client",
+    "architectures/decentralized/testing",
+    "architectures/decentralized/solana-tooling",
+    "shared/*",
+    "tools/rust-tools/*",
+    "website/wasm",
 ]
 resolver = "2"
 
@@ -35,13 +35,13 @@ psyche-solana-tooling = { path = "./architectures/decentralized/solana-tooling" 
 
 hf-hub = { git = "https://github.com/NousResearch/hf-hub.git", rev = "269dc3df4e194f9071ddbdbd25ed90d4990f9262" }
 tokio = { version = "1", features = [
-  "io-util",
-  "rt",
-  "rt-multi-thread",
-  "net",
-  "macros",
-  "time",
-  "signal",
+    "io-util",
+    "rt",
+    "rt-multi-thread",
+    "net",
+    "macros",
+    "time",
+    "signal",
 ] }
 tokio-stream = "0.1"
 tokio-util = "0.7.12"
@@ -61,21 +61,21 @@ chrono = { version = "0.4.38", features = ["clock"] }
 fast-math = "0.1"
 async-trait = "0.1.82"
 iroh = { git = "https://github.com/NousResearch/iroh", rev = "e0b8c597b301d8f5913e8c0ac57ec4d6d76595b3", features = [
-  "metrics",
+    "metrics",
 ] }
 iroh-relay = { git = "https://github.com/NousResearch/iroh", rev = "e0b8c597b301d8f5913e8c0ac57ec4d6d76595b3", features = [
-  "metrics",
+    "metrics",
 ] }
 iroh-blobs = { git = "https://github.com/NousResearch/iroh-blobs", rev = "f26e5a60c5b7fe32b5f2d4e590c7d55b97b346a5", features = [
-  "rpc",
-  "downloader",
-  "metrics",
+    "rpc",
+    "downloader",
+    "metrics",
 ] }
 iroh-gossip = { version = "0.34.1" }
 memmap2 = { version = "0.9.3", features = ["stable_deref_trait"] }
 indicatif = "0.17.5"
 tokenizers = { version = "0.20.0", default-features = false, features = [
-  "onig",
+    "onig",
 ] }
 tch = { git = "https://github.com/jquesnelle/tch-rs.git", rev = "5813b4d1789407924b450517639fcd0f7bf093e0" }
 torch-sys = { git = "https://github.com/jquesnelle/tch-rs.git", rev = "5813b4d1789407924b450517639fcd0f7bf093e0" }
@@ -90,14 +90,14 @@ clap-markdown = "0.1.4"
 
 anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5" }
 anchor-client = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5", features = [
-  "async",
+    "async",
 ] }
 anchor-lang-idl = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5", features = [
-  "build",
+    "build",
 ] }
 
 ts-rs = { git = "https://github.com/arilotter/ts-rs.git", rev = "92ce1752227fec9bb868ad8f25b26f110a795099", features = [
-  "psyche-impl",
+    "psyche-impl",
 ] }
 
 # dev only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 members = [
-    "architectures/centralized/*",
-    "architectures/decentralized/solana-client",
-    "architectures/decentralized/testing",
-    "architectures/decentralized/solana-tooling",
-    "shared/*",
-    "tools/rust-tools/*",
-    "website/wasm",
+  "architectures/centralized/*",
+  "architectures/decentralized/solana-client",
+  "architectures/decentralized/testing",
+  "architectures/decentralized/solana-tooling",
+  "shared/*",
+  "tools/rust-tools/*",
+  "website/wasm",
 ]
 resolver = "2"
 
@@ -35,13 +35,13 @@ psyche-solana-tooling = { path = "./architectures/decentralized/solana-tooling" 
 
 hf-hub = { git = "https://github.com/NousResearch/hf-hub.git", rev = "269dc3df4e194f9071ddbdbd25ed90d4990f9262" }
 tokio = { version = "1", features = [
-    "io-util",
-    "rt",
-    "rt-multi-thread",
-    "net",
-    "macros",
-    "time",
-    "signal",
+  "io-util",
+  "rt",
+  "rt-multi-thread",
+  "net",
+  "macros",
+  "time",
+  "signal",
 ] }
 tokio-stream = "0.1"
 tokio-util = "0.7.12"
@@ -61,21 +61,21 @@ chrono = { version = "0.4.38", features = ["clock"] }
 fast-math = "0.1"
 async-trait = "0.1.82"
 iroh = { git = "https://github.com/NousResearch/iroh", rev = "e0b8c597b301d8f5913e8c0ac57ec4d6d76595b3", features = [
-    "metrics",
+  "metrics",
 ] }
 iroh-relay = { git = "https://github.com/NousResearch/iroh", rev = "e0b8c597b301d8f5913e8c0ac57ec4d6d76595b3", features = [
-    "metrics",
+  "metrics",
 ] }
 iroh-blobs = { git = "https://github.com/NousResearch/iroh-blobs", rev = "f26e5a60c5b7fe32b5f2d4e590c7d55b97b346a5", features = [
-    "rpc",
-    "downloader",
-    "metrics",
+  "rpc",
+  "downloader",
+  "metrics",
 ] }
 iroh-gossip = { version = "0.34.1" }
 memmap2 = { version = "0.9.3", features = ["stable_deref_trait"] }
 indicatif = "0.17.5"
 tokenizers = { version = "0.20.0", default-features = false, features = [
-    "onig",
+  "onig",
 ] }
 tch = { git = "https://github.com/jquesnelle/tch-rs.git", rev = "5813b4d1789407924b450517639fcd0f7bf093e0" }
 torch-sys = { git = "https://github.com/jquesnelle/tch-rs.git", rev = "5813b4d1789407924b450517639fcd0f7bf093e0" }
@@ -90,14 +90,14 @@ clap-markdown = "0.1.4"
 
 anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5" }
 anchor-client = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5", features = [
-    "async",
+  "async",
 ] }
 anchor-lang-idl = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5", features = [
-    "build",
+  "build",
 ] }
 
 ts-rs = { git = "https://github.com/arilotter/ts-rs.git", rev = "92ce1752227fec9bb868ad8f25b26f110a795099", features = [
-    "psyche-impl",
+  "psyche-impl",
 ] }
 
 # dev only

--- a/shared/network/src/lib.rs
+++ b/shared/network/src/lib.rs
@@ -64,6 +64,9 @@ mod tcp;
 mod tui;
 mod util;
 
+#[cfg(test)]
+mod test;
+
 pub use authenticable_identity::{raw_p2p_verify, AuthenticatableIdentity, FromSignedBytesError};
 pub use download_manager::{DownloadComplete, DownloadFailed, DownloadType, TransmittableDownload};
 use iroh::defaults::DEFAULT_STUN_PORT;

--- a/shared/network/src/test.rs
+++ b/shared/network/src/test.rs
@@ -1,0 +1,408 @@
+use anyhow::Result;
+use iroh::{NodeAddr, RelayMode};
+use iroh_blobs::ticket::BlobTicket;
+use serde::{Deserialize, Serialize};
+use std::{sync::Arc, time::Duration};
+use tokio::{join, select, time::timeout};
+use tokio::{
+    sync::{
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
+        Mutex,
+    },
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+use crate::{
+    allowlist, psyche_relay_map, DiscoveryMode, DownloadType, NetworkConnection, NetworkEvent,
+    PeerList,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+enum Message {
+    Message { text: String },
+    DistroResult { blob_ticket: BlobTicket, step: u32 },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DistroResultBlob {
+    step: u32,
+    data: Vec<u8>,
+}
+
+type NC = NetworkConnection<Message, DistroResultBlob>;
+
+#[derive(Debug)]
+struct App {
+    cancel: CancellationToken,
+    current_step: u32,
+    network: NC,
+    our_id: NodeAddr,
+    should_wait_before: bool,
+    sender: bool,
+    tx_waiting_for_download: Option<UnboundedSender<String>>,
+    tx_retrying_download: Option<UnboundedSender<String>>,
+}
+
+impl App {
+    async fn run(&mut self) {
+        if self.sender {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            self.send().await;
+        }
+        loop {
+            select! {
+                _ = self.cancel.cancelled() => {
+                    println!("Node Cancelled");
+                    break;
+                }
+                event = self.network.poll_next() => {
+                    match event {
+                        Ok(event) => {
+                            if let Some(event) = event {
+                                self.on_network_event(event).await;
+                            }
+                        }
+                        Err(err) => {
+                            error!("Network error: {err}");
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn on_network_event(&mut self, event: NetworkEvent<Message, DistroResultBlob>) {
+        match event {
+            NetworkEvent::MessageReceived((from, Message::Message { text })) => {
+                info!(name:"message_recv_text", from=from.fmt_short(), text=text)
+            }
+            NetworkEvent::MessageReceived((_, Message::DistroResult { step, blob_ticket })) => {
+                let peers: Vec<NodeAddr> = self
+                    .network
+                    .get_all_peers()
+                    .await
+                    .iter()
+                    .map(|(peer, _)| peer.clone())
+                    .filter(|peer| peer.clone() != self.our_id)
+                    .collect();
+
+                if self.should_wait_before {
+                    println!("Waiting to download");
+                    if let Some(tx) = self.tx_waiting_for_download.take() {
+                        let _ = tx.send("aborting".to_string());
+                    }
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    println!("Downloading");
+                }
+
+                self.network
+                    .start_download(blob_ticket, step, DownloadType::DistroResult(peers))
+                    .await
+                    .unwrap();
+
+                if !self.should_wait_before {
+                    println!("Waiting to kill sender");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    if let Some(tx) = self.tx_waiting_for_download.take() {
+                        let _ = tx.send("aborting".to_string());
+                    }
+                }
+            }
+            NetworkEvent::DownloadComplete(_) => {
+                println!("Download complete");
+            }
+            NetworkEvent::DownloadFailed(result) => {
+                if let Some(tx) = self.tx_retrying_download.take() {
+                    let _ = tx.send("donwload failed".to_string());
+                }
+                println!(
+                    "Download failed: {}! Reason: {}",
+                    result.blob_ticket.hash(),
+                    result.error
+                )
+            }
+            _ => {
+                // Handle other events or explicitly ignore them
+                println!("Unhandled network event");
+            }
+        }
+    }
+
+    async fn send(&mut self) {
+        const DATA_SIZE_MB: usize = 1000;
+        let data = vec![0u8; DATA_SIZE_MB * 1024 * 1024];
+        let step = self.current_step;
+
+        let blob_ticket = match self
+            .network
+            .add_downloadable(DistroResultBlob { step, data }, step)
+            .await
+        {
+            Ok(bt) => {
+                println!("Uploaded blob");
+                bt
+            }
+            Err(e) => {
+                println!("Couldn't add downloadable for step {step}. {}", e);
+                return;
+            }
+        };
+
+        let message = Message::DistroResult {
+            step,
+            blob_ticket: blob_ticket.clone(),
+        };
+
+        if let Err(e) = self.network.broadcast(&message).await {
+            println!("Error sending message: {}", e);
+        } else {
+            println!("broadcasted message for step {step}: {}", blob_ticket);
+        }
+    }
+}
+
+async fn spawn_new_node(
+    is_sender: bool,
+    peer_list: Option<PeerList>,
+    should_wait_to_download: bool,
+    cancel_token: CancellationToken,
+) -> Result<(
+    Option<UnboundedReceiver<String>>,
+    Option<UnboundedReceiver<String>>,
+    PeerList,
+    JoinHandle<()>,
+)> {
+    let (tx_waiting_for_download, rx_waiting_for_download) = if !is_sender {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    let (tx_retrying_download, rx_retrying_download) = if !is_sender {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    let PeerList(peers) = peer_list.unwrap_or_default();
+
+    println!("joining gossip room");
+
+    let network = NC::init(
+        "test",
+        None,
+        None,
+        RelayMode::Custom(psyche_relay_map()),
+        DiscoveryMode::Local,
+        peers,
+        None,
+        allowlist::AllowAll,
+        20,
+    )
+    .await?;
+
+    let node_addr = network.router().endpoint().node_addr().await.unwrap();
+    let join_id = PeerList(vec![node_addr]);
+
+    let our_id = network
+        .get_all_peers()
+        .await
+        .get(0)
+        .map(|(addr, _)| addr.clone())
+        .ok_or_else(|| anyhow::anyhow!("No peers found"))?;
+
+    let mut app = App {
+        cancel: cancel_token,
+        current_step: 0,
+        network,
+        our_id,
+        should_wait_before: should_wait_to_download,
+        tx_waiting_for_download,
+        sender: is_sender,
+        tx_retrying_download,
+    };
+
+    let handle = tokio::spawn(async move {
+        app.run().await;
+        println!("Node finished running");
+    });
+
+    Ok((
+        rx_waiting_for_download,
+        rx_retrying_download,
+        join_id,
+        handle,
+    ))
+}
+
+#[tokio::test]
+async fn test_retry_connection() -> Result<()> {
+    println!("Spawning first node (sender)");
+    let sender_cancel = CancellationToken::new();
+    let (_, _, join_id, handle_1) = spawn_new_node(
+        true,  // is_sender
+        None,  // peer_list
+        false, // wait
+        sender_cancel.clone(),
+    )
+    .await?;
+
+    // Give the first node time to initialize
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    println!("Spawning second node (receiver)");
+
+    let receiver_cancel = CancellationToken::new();
+    let (rx_waiting, rx_retrying, _, handle_2) = spawn_new_node(
+        false, // is_sender
+        Some(join_id),
+        true, // wait
+        receiver_cancel.clone(),
+    )
+    .await?;
+
+    // Set up test completion logic
+    let test_completed = Arc::new(Mutex::new(false));
+    let test_completed_clone = test_completed.clone();
+
+    // Handle waiting for download signal
+    if let Some(mut rx) = rx_waiting {
+        let sender_cancel_clone = sender_cancel.clone();
+        tokio::spawn(async move {
+            if let Some(_) = rx.recv().await {
+                println!("ABORTING SENDER NODE");
+                sender_cancel_clone.cancel();
+            }
+        });
+    }
+
+    // Handle retry signal (test completion)
+    if let Some(mut rx) = rx_retrying {
+        tokio::spawn(async move {
+            if let Some(_) = rx.recv().await {
+                println!("TEST PASSED - Retry detected");
+                let mut completed = test_completed_clone.lock().await;
+                *completed = true;
+            }
+        });
+    }
+
+    // Wait for test completion with timeout
+    let test_duration = Duration::from_secs(40);
+    let result = timeout(test_duration, async {
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let completed = test_completed.lock().await;
+            if *completed {
+                break;
+            }
+        }
+    })
+    .await;
+
+    // Clean up
+    sender_cancel.cancel();
+    receiver_cancel.cancel();
+
+    match result {
+        Ok(_) => {
+            println!("Test completed successfully");
+            let _ = join!(handle_1, handle_2);
+            Ok(())
+        }
+        Err(_) => {
+            error!("Test timed out after {} seconds", test_duration.as_secs());
+            let _ = join!(handle_1, handle_2);
+            Err(anyhow::anyhow!("Test timed out"))
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_retry_connection_mid_download() -> Result<()> {
+    println!("SPAWNING FIRST NODE (SENDER)");
+
+    let sender_cancel = CancellationToken::new();
+    let (_, _, join_id, handle_1) = spawn_new_node(
+        true,  // is_sender
+        None,  // peer_list
+        false, // wait
+        sender_cancel.clone(),
+    )
+    .await?;
+
+    // Give the first node time to initialize
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    println!("SPAWNING SECOND NODE (RECEIVER)");
+
+    let receiver_cancel = CancellationToken::new();
+    let (rx_waiting, rx_retrying, _, handle_2) = spawn_new_node(
+        false, // is_sender
+        Some(join_id),
+        false, // wait
+        receiver_cancel.clone(),
+    )
+    .await?;
+
+    // Set up test completion logic
+    let test_completed = Arc::new(Mutex::new(false));
+    let test_completed_clone = test_completed.clone();
+
+    // Handle waiting for download signal
+    if let Some(mut rx) = rx_waiting {
+        let sender_cancel_clone = sender_cancel.clone();
+        tokio::spawn(async move {
+            if let Some(_) = rx.recv().await {
+                println!("ABORTING SENDER NODE");
+                sender_cancel_clone.cancel();
+            }
+        });
+    }
+
+    // Handle retry signal (test completion)
+    if let Some(mut rx) = rx_retrying {
+        tokio::spawn(async move {
+            if let Some(_) = rx.recv().await {
+                println!("TEST PASSED - Retry detected");
+                let mut completed = test_completed_clone.lock().await;
+                *completed = true;
+            }
+        });
+    }
+
+    // Wait for test completion with timeout
+    let test_duration = Duration::from_secs(50);
+    let result = timeout(test_duration, async {
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let completed = test_completed.lock().await;
+            if *completed {
+                break;
+            }
+        }
+    })
+    .await;
+
+    // Clean up
+    sender_cancel.cancel();
+    receiver_cancel.cancel();
+
+    match result {
+        Ok(_) => {
+            println!("Test completed successfully");
+            let _ = join!(handle_1, handle_2);
+            Ok(())
+        }
+        Err(_) => {
+            error!("Test timed out after {} seconds", test_duration.as_secs());
+            let _ = join!(handle_1, handle_2);
+            Err(anyhow::anyhow!("Test timed out"))
+        }
+    }
+}


### PR DESCRIPTION
New test setup for the network module introduces two nodes, a sender and a receiver, used to validate blob download failure behavior under crash conditions with a 1 GB blob:

* **Test 1**: Verifies that a `DownloadFailed` event is received if the sender crashes before the receiver begins downloading the blob.
* **Test 2**: Verifies that a `DownloadFailed` event is received if the sender crashes mid-transfer while sharing the blob.