### PR TITLE
Fixes in MMLU, BoolQ and OpenBookQA evaluations

### DIFF
--- a/shared/eval/src/tasks/boolq.rs
+++ b/shared/eval/src/tasks/boolq.rs
@@ -73,16 +73,16 @@ impl BoolQ {
 
 impl LogLikelihoodTask for BoolQ {
     fn get_documents(&self) -> Vec<Document> {
-        self.test_dataset
+        self.validation_dataset
             .iter()
-            .map(|row| BoolQ::row_to_document(&self.test_dataset, row))
+            .map(|row| BoolQ::row_to_document(&self.validation_dataset, row))
             .collect()
     }
 
     fn get_fewshot_documents(&self) -> Vec<Document> {
-        self.validation_dataset
+        self.test_dataset
             .iter()
-            .map(|row| BoolQ::row_to_document(&self.validation_dataset, row))
+            .map(|row| BoolQ::row_to_document(&self.test_dataset, row))
             .collect()
     }
 }

--- a/shared/eval/src/tasks/boolq.rs
+++ b/shared/eval/src/tasks/boolq.rs
@@ -23,8 +23,18 @@ pub struct BoolQ {
 impl BoolQ {
     pub fn load() -> Result<TaskType> {
         let ret = Self {
-            test_dataset: load_dataset("google/boolq", None, Split::Train, None)?,
-            validation_dataset: load_dataset("google/boolq", None, Split::Validation, None)?,
+            test_dataset: load_dataset(
+                "aps/super_glue",
+                None,
+                Split::Train,
+                Some("boolq".to_string()),
+            )?,
+            validation_dataset: load_dataset(
+                "aps/super_glue",
+                None,
+                Split::Validation,
+                Some("boolq".to_string()),
+            )?,
         };
         Ok(TaskType::LogLikelihood(Box::new(ret)))
     }
@@ -44,24 +54,13 @@ impl BoolQ {
             .unwrap()
             .to_owned();
 
-        let choices = vec!["yes".to_string(), "no".to_string()];
+        let choices = vec!["no".to_string(), "yes".to_string()];
 
         let text = format!("{}\nQuestion: {}?\nAnswer:", passage, question);
 
         let answer = row
-            .get_bool(dataset.get_column_id("answer").unwrap())
-            .unwrap();
-
-        let answer = choices
-            .iter()
-            .position(|choice_str| {
-                choice_str
-                    == match answer {
-                        true => "yes",
-                        false => "no",
-                    }
-            })
-            .unwrap();
+            .get_long(dataset.get_column_id("label").unwrap())
+            .unwrap() as usize;
 
         Document {
             text,

--- a/shared/eval/src/tasks/mmlu.rs
+++ b/shared/eval/src/tasks/mmlu.rs
@@ -54,12 +54,11 @@ impl MMLU {
             .map(|i| ASCII_UPPERCASE[i].to_owned())
             .collect::<Vec<_>>();
         let text = format!(
-            "The following are multiple choice questions (with answers) about {}.\n\n{}\n{}\nAnswer: ",
+            "The following are multiple choice questions (with answers) about {}.\n\n{}\n{}\nAnswer:",
             subject,
             question,
             options.join("\n")
         );
-
         let answer = row
             .get_long(dataset.get_column_id("answer").unwrap())
             .unwrap() as usize;

--- a/shared/eval/src/tasks/mmlu.rs
+++ b/shared/eval/src/tasks/mmlu.rs
@@ -36,7 +36,11 @@ impl MMLU {
     }
 
     fn row_to_document(dataset: &Dataset, row: Row) -> Document {
-        let text = row
+        let subject = row
+            .get_string(dataset.get_column_id("subject").unwrap())
+            .unwrap()
+            .replace("_", " ");
+        let question = row
             .get_string(dataset.get_column_id("question").unwrap())
             .unwrap()
             .to_owned();
@@ -49,10 +53,17 @@ impl MMLU {
         let choices = (0..options.len())
             .map(|i| ASCII_UPPERCASE[i].to_owned())
             .collect::<Vec<_>>();
-        let text = format!("{}\n{}\nAnswer: ", text, options.join("\n"));
+        let text = format!(
+            "The following are multiple choice questions (with answers) about {}.\n\n{}\n{}\nAnswer: ",
+            subject,
+            question,
+            options.join("\n")
+        );
+
         let answer = row
             .get_long(dataset.get_column_id("answer").unwrap())
             .unwrap() as usize;
+
         Document {
             text,
             choices,

--- a/shared/eval/src/tasks/openbookqa.rs
+++ b/shared/eval/src/tasks/openbookqa.rs
@@ -27,8 +27,18 @@ pub struct OpenbookQA {
 impl OpenbookQA {
     pub fn load() -> Result<TaskType> {
         let ret = Self {
-            test_dataset: load_dataset("allenai/openbookqa", None, Split::Test, None)?,
-            validation_dataset: load_dataset("allenai/openbookqa", None, Split::Validation, None)?,
+            test_dataset: load_dataset(
+                "allenai/openbookqa",
+                None,
+                Split::Test,
+                Some("main".to_string()),
+            )?,
+            validation_dataset: load_dataset(
+                "allenai/openbookqa",
+                None,
+                Split::Validation,
+                Some("main".to_string()),
+            )?,
         };
         Ok(TaskType::LogLikelihood(Box::new(ret)))
     }


### PR DESCRIPTION
# Corrections in evaluation benchmarks,
After reviewing the [lm_eval](https://github.com/EleutherAI/lm-evaluation-harness) evaluations implementation, I found we were having some discrepancies in the inputs we pass to the model in some evaluations

### MMLU
* Modify the prompt we pass to the model. [See lm_eval repo](https://github.com/EleutherAI/lm-evaluation-harness/blob/8bc4afff22e73995883de41018388428e39f8a92/lm_eval/tasks/mmlu/flan_cot_zeroshot/mmlu_computer_security.yaml)  

### BoolQ
* Modify the dataset used. [See lm_eval repo](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/super_glue/boolq/default.yaml)

### OpenBookQA
* Modify the dataset used. [See lm_eval repo](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/openbookqa/openbookqa.yaml)

## Model [TinyLlama/TinyLlama-1.1B-Chat-v0.4](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v0.4)
### Psyche Benchmarks
```
BoolQ: {"acc_norm": 0.5694189602446483, "acc": 0.5694189602446483}
MMLU: {"acc_norm": 0.2516735507762427, "acc": 0.2516735507762427}
OpenBookQA: {"acc": 0.236, "acc_norm": 0.348}
```
### lm_eval
```
"boolq": {
      "alias": "boolq",
      "acc,none": 0.5730886850152905,
      "acc_stderr,none": 0.008651119069643822
    }
"mmlu": {
      "acc,none": 0.25181598062953997,
      "acc_stderr,none": 0.0036617250254308807,
      "alias": "mmlu"
    }
"openbookqa": {
      "alias": "openbookqa",
      "acc,none": 0.254,
      "acc_stderr,none": 0.019486596801643382,
      "acc_norm,none": 0.354,
      "acc_norm_stderr,none": 0.021407582047916447
    }
```
Note: We still don't have exactly the same results as `lm_eval`, but I think that now the difference is because of the log likelihood calculation