### PR TITLE
feat: return error if number of clients exceeds number of global batches to assign

### DIFF
--- a/architectures/decentralized/solana-client/src/app.rs
+++ b/architectures/decentralized/solana-client/src/app.rs
@@ -288,7 +288,7 @@ impl App {
                         Err(err) => debug!("Tick simulation error: {err}")
                     };
                 }
-                update = async { updates.recv().await } => {
+                update = updates.recv() => {
                     latest_update = update?;
                     match latest_update.run_state {
                         RunState::WaitingForMembers => {

--- a/architectures/decentralized/solana-client/src/backend.rs
+++ b/architectures/decentralized/solana-client/src/backend.rs
@@ -12,7 +12,7 @@ use anchor_client::{
         signature::{Keypair, Signature, Signer},
         system_instruction,
     },
-    Client, ClientError, Cluster, Program,
+    Client, Cluster, Program,
 };
 use anyhow::{anyhow, Context, Result};
 use futures_util::StreamExt;

--- a/architectures/decentralized/solana-client/src/backend.rs
+++ b/architectures/decentralized/solana-client/src/backend.rs
@@ -12,7 +12,7 @@ use anchor_client::{
         signature::{Keypair, Signature, Signer},
         system_instruction,
     },
-    Client, Cluster, Program,
+    Client, ClientError, Cluster, Program,
 };
 use anyhow::{anyhow, Context, Result};
 use futures_util::StreamExt;

--- a/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/instance_state.rs
+++ b/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/instance_state.rs
@@ -305,7 +305,7 @@ impl CoordinatorInstanceState {
     }
 
     pub fn join_run(&mut self, id: ClientId) -> Result<()> {
-        let exisiting = match self
+        let existing = match self
             .clients_state
             .clients
             .iter_mut()
@@ -323,21 +323,25 @@ impl CoordinatorInstanceState {
             None => false,
         };
 
-        if !exisiting
-            && self
-                .clients_state
-                .clients
-                .push(Client {
-                    id,
-                    earned: 0,
-                    slashed: 0,
-                    active: self.clients_state.next_active,
-                    _unused: Default::default(),
-                })
-                .is_err()
-        {
-            return err!(ProgramError::ClientsFull);
-        } else {
+        if !existing {
+            let total_num_clients = self.clients_state.clients.len() as u16;
+            if self.coordinator.config.global_batch_size_end
+                == total_num_clients
+            {
+                return err!(ProgramError::ClientsFull);
+            }
+
+            let new_client = Client {
+                id,
+                earned: 0,
+                slashed: 0,
+                active: self.clients_state.next_active,
+                _unused: Default::default(),
+            };
+
+            if self.clients_state.clients.push(new_client).is_err() {
+                return err!(ProgramError::ClientsFull);
+            }
             msg!(
                 "New client {} joined, {} total clients",
                 id.signer,

--- a/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/instance_state.rs
+++ b/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/instance_state.rs
@@ -328,7 +328,7 @@ impl CoordinatorInstanceState {
             if self.coordinator.config.global_batch_size_end
                 == total_num_clients
             {
-                return err!(ProgramError::ClientsFull);
+                return err!(ProgramError::MoreClientsThanBatches);
             }
 
             let new_client = Client {

--- a/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/program_error.rs
+++ b/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/program_error.rs
@@ -71,6 +71,9 @@ pub enum ProgramError {
 
     #[msg("Coordinator error: Invalid committee proof")]
     CoordinatorErrorInvalidCommitteeProof,
+
+    #[msg("There are more clients than total number of batches to assign")]
+    MoreClientsThanBatches,
 }
 
 impl From<CoordinatorError> for ProgramError {

--- a/architectures/decentralized/testing/tests/integration_tests.rs
+++ b/architectures/decentralized/testing/tests/integration_tests.rs
@@ -879,7 +879,6 @@ async fn test_solana_subscriptions() {
 #[serial]
 async fn test_everybody_leaves_in_warmup() {
     // set test variables
-    let run_id = "test".to_string();
     let docker = Arc::new(Docker::connect_with_socket_defaults().unwrap());
 
     // initialize a Solana run with 1 client
@@ -888,19 +887,15 @@ async fn test_everybody_leaves_in_warmup() {
 
     // initialize DockerWatcher
     let mut watcher = DockerWatcher::new(docker.clone());
-    let solana_client = SolanaTestClient::new(run_id).await;
     let client_1_name = format!("{CLIENT_CONTAINER_PREFIX}-1");
 
     watcher
-        .monitor_container(&client_1_name, vec![JsonFilter::StateChange])
+        .monitor_container(&client_1_name, vec![IntegrationTestLogMarker::StateChange])
         .unwrap();
 
     while let Some(response) = watcher.log_rx.recv().await {
         match response {
             Response::StateChange(_timestamp, _client_id, old_state, new_state, ..) => {
-                let coordinator_state = solana_client.get_run_state().await;
-                assert_eq!(coordinator_state.to_string(), new_state.to_string());
-
                 println!("Changing from {old_state} to {new_state}");
 
                 if old_state == RunState::WaitingForMembers.to_string()
@@ -921,14 +916,12 @@ async fn test_everybody_leaves_in_warmup() {
 
     let client_2_name = format!("{CLIENT_CONTAINER_PREFIX}-2");
     watcher
-        .monitor_container(&client_2_name, vec![JsonFilter::StateChange])
+        .monitor_container(&client_2_name, vec![IntegrationTestLogMarker::StateChange])
         .unwrap();
 
     while let Some(response) = watcher.log_rx.recv().await {
         match response {
             Response::StateChange(_timestamp, _client_id, old_state, new_state, ..) => {
-                let coordinator_state = solana_client.get_run_state().await;
-                assert_eq!(coordinator_state.to_string(), new_state.to_string());
                 println!("Changing from {old_state} to {new_state}");
 
                 if old_state == RunState::RoundWitness.to_string()


### PR DESCRIPTION
Closes #48

Not too important for a real case scenario, but for small training runs made for testing this is a quality of life feature.
We noticed that when there are more clients than the number of global batch size set in the config, some client is not assigned any batch and eventually is kicked. Not only this, but the coordinator ends in some weird state and other clients are kicked too.

This PR adds a small check when a new client joins; if the global batch size is equal to the number of clients present in the run, then an error is raised and the new client doesn't join the run