### PR TITLE
Fix model evaluations spikes

### DIFF
--- a/shared/core/src/running_average.rs
+++ b/shared/core/src/running_average.rs
@@ -72,10 +72,13 @@ impl RunningAverage {
         entries.get(name).and_then(|entry| entry.average())
     }
 
+    /// Get averages of entries
+    /// Skips entries that have not reached their maximum buffer size to avoid unconfident scores
     pub fn get_all_averages(&self) -> HashMap<String, Option<f64>> {
         let entries = self.entries.read().unwrap();
         entries
             .iter()
+            .filter(|(_, entry)| entry.buffer.len() == entry.max_size)
             .map(|(name, entry)| (name.clone(), entry.average()))
             .collect()
     }


### PR DESCRIPTION
We are seeing some spikes in the model evaluations.
![image](https://github.com/user-attachments/assets/b5e21fa1-25e5-49ad-a525-b2c410eb2e79)
We believe it is because clients are reporting benchmark scores with few samples, causing spikes in the evaluation graph.
Now, clients will need to wait until their buffer is full to report model scores.