### PR TITLE
increase WAITING_FOR_MEMBERS_EXTRA_SECONDS to 10

### DIFF
--- a/shared/coordinator/src/coordinator.rs
+++ b/shared/coordinator/src/coordinator.rs
@@ -17,7 +17,7 @@ pub const SOLANA_MAX_NUM_WITNESSES: usize = 32;
 
 pub const BLOOM_FALSE_RATE: f64 = 0.01f64;
 pub const WITNESS_QUORUM_RAIO: f64 = 2.0f64 / 3.0f64;
-pub const WAITING_FOR_MEMBERS_EXTRA_SECONDS: u64 = 3;
+pub const WAITING_FOR_MEMBERS_EXTRA_SECONDS: u64 = 10;
 
 // bloom filter with 1024 bits (16 u64)
 pub type WitnessBloom = Bloom<16, 8>;


### PR DESCRIPTION
At 50+ nodes not all are able to make it in the 3 second window. We should fix this generally (#105) but this is a non-storage-breaking change (i.e. we can safely redeploy)