### PR TITLE
fix: hunting down remaining Repr(Rust)

### DIFF
--- a/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/client.rs
+++ b/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/client.rs
@@ -42,7 +42,6 @@ impl Debug for Client {
     }
 }
 
-#[repr(C)]
 #[derive(
     InitSpace,
     Copy,
@@ -56,6 +55,7 @@ impl Debug for Client {
     Pod,
     TS,
 )]
+#[repr(C)]
 pub struct ClientId {
     #[ts(type = "number[]")]
     pub signer: Pubkey,

--- a/shared/coordinator/src/coordinator.rs
+++ b/shared/coordinator/src/coordinator.rs
@@ -22,7 +22,6 @@ pub const WAITING_FOR_MEMBERS_EXTRA_SECONDS: u64 = 3;
 // bloom filter with 1024 bits (16 u64)
 pub type WitnessBloom = Bloom<16, 8>;
 
-#[repr(u8)]
 #[derive(
     Clone,
     Copy,
@@ -37,6 +36,7 @@ pub type WitnessBloom = Bloom<16, 8>;
     InitSpace,
     TS,
 )]
+#[repr(u8)]
 pub enum RunState {
     #[default]
     Uninitialized = 0,
@@ -49,7 +49,6 @@ pub enum RunState {
     Paused = 7,
 }
 
-#[repr(u8)]
 #[derive(
     Clone,
     Copy,
@@ -64,6 +63,7 @@ pub enum RunState {
     InitSpace,
     TS,
 )]
+#[repr(u8)]
 pub enum ClientState {
     #[default]
     Healthy = 0,
@@ -85,6 +85,7 @@ pub enum ClientState {
     TS,
 )]
 #[serde(bound = "I: NodeIdentity")]
+#[repr(C)]
 pub struct Client<I> {
     pub id: I,
     pub state: ClientState,
@@ -202,6 +203,7 @@ impl WitnessEvalResult {
 }
 
 #[derive(Clone, Copy, Debug)]
+#[repr(u8)]
 pub enum CoordinatorError {
     NoActiveRound,
     InvalidWitness,

--- a/shared/core/src/fixed_string.rs
+++ b/shared/core/src/fixed_string.rs
@@ -27,6 +27,7 @@ pub struct FixedStringError((usize, usize));
     InitSpace,
     Zeroable,
 )]
+#[repr(C)]
 pub struct FixedString<const L: usize>(
     #[serde(
         serialize_with = "serde_serialize_string",

--- a/shared/core/src/fixed_vec.rs
+++ b/shared/core/src/fixed_vec.rs
@@ -7,6 +7,7 @@ use ts_rs::TS;
 
 #[derive(Clone, Copy, Zeroable, AnchorSerialize, AnchorDeserialize, TS)]
 #[ts(type = "Array<T>", bound = "T: TS")]
+#[repr(C)]
 pub struct FixedVec<T, const N: usize> {
     data: [T; N],
     len: u64,

--- a/shared/core/src/small_boolean.rs
+++ b/shared/core/src/small_boolean.rs
@@ -5,7 +5,6 @@ use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
-#[repr(transparent)]
 #[derive(
     Copy,
     Clone,
@@ -21,6 +20,7 @@ use ts_rs::TS;
     InitSpace,
     TS,
 )]
+#[repr(transparent)]
 pub struct SmallBoolean(pub u8);
 
 impl Debug for SmallBoolean {


### PR DESCRIPTION
We use bytemuck for serialization/deserialization, meaning that we use the Raw RAM layout for serialization. The RAM layout depends on the `Repr()`.

One big No-no here is that the `Repr(Rust)` does NOT guarantee anything layout wise and its actual behaviour is undefined (although compiler internals as of today make it somewhat predictable for simple cases).

This means that `Repr(Rust)` is BY DEFINITION not cross-platform (aka typescript incompatible for example)

This PR hunts down the last few remaining forgotten `Repr(Rust)` but with most importantly: THIS PR DOES NOT CHANGE THE BINARY LAYOUT, just translate to the non `Repr(Rust)` current equivalent of the current behaviour.