### PR TITLE
fix: add space before evaluating answers for log-likelihood evals

### DIFF
--- a/shared/eval/examples/evaluate.rs
+++ b/shared/eval/examples/evaluate.rs
@@ -11,6 +11,9 @@ struct Args {
     model: String,
 
     #[arg(long)]
+    revision: Option<String>,
+
+    #[arg(long)]
     hf_token: Option<String>,
 
     #[arg(long, default_value_t = ALL_TASK_NAMES.join(","))]
@@ -34,7 +37,7 @@ fn main() -> Result<()> {
         .map(|x| tasktype_from_name(x).map(|y| Task::new(y, args.num_fewshot, args.seed)))
         .collect();
     let tasks = tasks?;
-    let repo = download_model_repo_sync(&args.model, None, None, args.hf_token, true)?;
+    let repo = download_model_repo_sync(&args.model, args.revision, None, args.hf_token, true)?;
     let tokenizer = auto_tokenizer(&repo)?;
     let mut model = auto_model_for_causal_lm_from_pretrained(
         repo,

--- a/shared/eval/src/harness.rs
+++ b/shared/eval/src/harness.rs
@@ -81,8 +81,9 @@ impl TokenizedLLHDocument {
             .choices
             .into_iter()
             .map(|x| {
+                let choice_with_space = format!(" {}", x);
                 let choice = tokenizer
-                    .encode(x.clone(), false)
+                    .encode(choice_with_space, false)
                     .unwrap()
                     .get_ids()
                     .iter()


### PR DESCRIPTION
After fix:

`lm-eval` ref:
```
hf (pretrained=meta-llama/Meta-Llama-3-8B), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 8
|    Tasks    |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|-------------|------:|------|-----:|--------|---|-----:|---|-----:|
|arc_challenge|      1|none  |     0|acc     |↑  |0.5043|±  |0.0146|
|             |       |none  |     0|acc_norm|↑  |0.5316|±  |0.0146|
|arc_easy     |      1|none  |     0|acc     |↑  |0.8005|±  |0.0082|
|             |       |none  |     0|acc_norm|↑  |0.7782|±  |0.0085|
|boolq        |      2|none  |     0|acc     |↑  |0.8107|±  |0.0069|
|hellaswag    |      1|none  |     0|acc     |↑  |0.6005|±  |0.0049|
|             |       |none  |     0|acc_norm|↑  |0.7915|±  |0.0041|
|openbookqa   |      1|none  |     0|acc     |↑  |0.3460|±  |0.0213|
|             |       |none  |     0|acc_norm|↑  |0.4480|±  |0.0223|
|piqa         |      1|none  |     0|acc     |↑  |0.7960|±  |0.0094|
|             |       |none  |     0|acc_norm|↑  |0.8090|±  |0.0092|
```

`evaluate`
```
ARC-Easy: {"acc_norm": 0.7638888888888888, "acc": 0.8068181818181818}
ARC-Challenge: {"acc_norm": 0.5315699658703071, "acc": 0.5187713310580204}
BoolQ: {"acc": 0.8177370030581039, "acc_norm": 0.8177370030581039}
Hellaswag: {"acc_norm": 0.7876916948814977, "acc": 0.6057558255327624}
OpenBookQA: {"acc": 0.338, "acc_norm": 0.452}
PIQA: {"acc": 0.7905331882480957, "acc_norm": 0.7981501632208923}
```