### PR TITLE
fix: retry fixing reward distribution

### DIFF
--- a/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/instance_state.rs
+++ b/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/instance_state.rs
@@ -128,35 +128,41 @@ impl CoordinatorInstanceState {
             Ok(TickResult::EpochEnd(success)) => {
                 msg!("Epoch end, sucecsss: {}", success);
 
-                let mut i = 0;
-                let mut j = 0;
                 let finished_clients = &self.coordinator.epoch_state.clients;
                 let exited_clients =
                     &self.coordinator.epoch_state.exited_clients;
 
+                let mut finished_client_index = 0;
+                let mut exited_client_index = 0;
+
                 for client in self.clients_state.clients.iter_mut() {
-                    if i < finished_clients.len()
-                        && client.id == finished_clients[i].id
+                    if finished_client_index < finished_clients.len()
+                        && client.id.signer
+                            == finished_clients[finished_client_index].id.signer
                     {
-                        if finished_clients[i].state == ClientState::Healthy {
+                        if finished_clients[finished_client_index].state
+                            == ClientState::Healthy
+                        {
                             client.earned += self
                                 .clients_state
                                 .current_epoch_rates
                                 .earning_rate;
                         }
-                        i += 1;
+                        finished_client_index += 1;
                     }
-
-                    if j < exited_clients.len()
-                        && client.id == exited_clients[j].id
+                    if exited_client_index < exited_clients.len()
+                        && client.id.signer
+                            == exited_clients[exited_client_index].id.signer
                     {
-                        if exited_clients[j].state == ClientState::Ejected {
+                        if exited_clients[exited_client_index].state
+                            == ClientState::Ejected
+                        {
                             client.slashed += self
                                 .clients_state
                                 .current_epoch_rates
                                 .slashing_rate;
                         }
-                        j += 1;
+                        exited_client_index += 1;
                     }
                 }
             },

--- a/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/lib.rs
+++ b/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/lib.rs
@@ -270,7 +270,7 @@ pub struct OwnerCoordinatorAccounts<'info> {
         bump = coordinator_instance.bump,
         constraint = coordinator_instance.main_authority == authority.key()
     )]
-    pub coordinator_instance: Account<'info, CoordinatorInstance>,
+    pub coordinator_instance: Box<Account<'info, CoordinatorInstance>>,
 
     #[account(
         mut,
@@ -291,7 +291,7 @@ pub struct PermissionlessCoordinatorAccounts<'info> {
         ],
         bump = coordinator_instance.bump
     )]
-    pub coordinator_instance: Account<'info, CoordinatorInstance>,
+    pub coordinator_instance: Box<Account<'info, CoordinatorInstance>>,
 
     #[account(
         mut,

--- a/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/logic/free_coordinator.rs
+++ b/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/logic/free_coordinator.rs
@@ -25,7 +25,7 @@ pub struct FreeCoordinatorAccounts<'info> {
         constraint = coordinator_instance.main_authority == authority.key(),
         close = spill,
     )]
-    pub coordinator_instance: Account<'info, CoordinatorInstance>,
+    pub coordinator_instance: Box<Account<'info, CoordinatorInstance>>,
 
     #[account(
         mut,

--- a/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/logic/init_coordinator.rs
+++ b/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/logic/init_coordinator.rs
@@ -22,7 +22,7 @@ pub struct InitCoordinatorAccounts<'info> {
         ],
         bump
     )]
-    pub coordinator_instance: Account<'info, CoordinatorInstance>,
+    pub coordinator_instance: Box<Account<'info, CoordinatorInstance>>,
 
     /// CHECK: TODO TODO UNSAFE UNSAFE
     #[account(

--- a/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/logic/join_run.rs
+++ b/architectures/decentralized/solana-coordinator/programs/solana-coordinator/src/logic/join_run.rs
@@ -22,7 +22,7 @@ pub struct JoinRunAccounts<'info> {
             JOIN_RUN_AUTHORIZATION_SCOPE,
         ),
     )]
-    pub authorization: Account<'info, Authorization>,
+    pub authorization: Box<Account<'info, Authorization>>,
 
     #[account(
         seeds = [
@@ -31,7 +31,7 @@ pub struct JoinRunAccounts<'info> {
         ],
         bump = coordinator_instance.bump,
     )]
-    pub coordinator_instance: Account<'info, CoordinatorInstance>,
+    pub coordinator_instance: Box<Account<'info, CoordinatorInstance>>,
 
     #[account(
         mut,

--- a/architectures/decentralized/solana-tooling/src/process_coordinator_instructions.rs
+++ b/architectures/decentralized/solana-tooling/src/process_coordinator_instructions.rs
@@ -12,6 +12,7 @@ use psyche_solana_coordinator::find_coordinator_instance;
 use psyche_solana_coordinator::instruction::FreeCoordinator;
 use psyche_solana_coordinator::instruction::InitCoordinator;
 use psyche_solana_coordinator::instruction::JoinRun;
+use psyche_solana_coordinator::instruction::SetFutureEpochRates;
 use psyche_solana_coordinator::instruction::SetPaused;
 use psyche_solana_coordinator::instruction::Tick;
 use psyche_solana_coordinator::instruction::Update;
@@ -156,6 +157,34 @@ pub async fn process_coordinator_set_paused(
     let instruction = Instruction {
         accounts: accounts.to_account_metas(None),
         data: SetPaused { paused }.data(),
+        program_id: psyche_solana_coordinator::ID,
+    };
+    endpoint
+        .process_instruction_with_signers(instruction, payer, &[authority])
+        .await
+}
+
+pub async fn process_coordiantor_set_future_epoch_rates(
+    endpoint: &mut ToolboxEndpoint,
+    payer: &Keypair,
+    authority: &Keypair,
+    coordinator_instance: &Pubkey,
+    coordinator_account: &Pubkey,
+    epoch_earning_rate: Option<u64>,
+    epoch_slashing_rate: Option<u64>,
+) -> Result<Signature, ToolboxEndpointError> {
+    let accounts = OwnerCoordinatorAccounts {
+        authority: authority.pubkey(),
+        coordinator_instance: *coordinator_instance,
+        coordinator_account: *coordinator_account,
+    };
+    let instruction = Instruction {
+        accounts: accounts.to_account_metas(None),
+        data: SetFutureEpochRates {
+            epoch_earning_rate,
+            epoch_slashing_rate,
+        }
+        .data(),
         program_id: psyche_solana_coordinator::ID,
     };
     endpoint

--- a/architectures/decentralized/solana-tooling/tests/suites/memnet_coordinator_full_round.rs
+++ b/architectures/decentralized/solana-tooling/tests/suites/memnet_coordinator_full_round.rs
@@ -1,0 +1,361 @@
+use psyche_coordinator::model::Checkpoint;
+use psyche_coordinator::model::HubRepo;
+use psyche_coordinator::model::LLMArchitecture;
+use psyche_coordinator::model::LLMTrainingDataLocation;
+use psyche_coordinator::model::LLMTrainingDataType;
+use psyche_coordinator::model::Model;
+use psyche_coordinator::model::LLM;
+use psyche_coordinator::CoordinatorConfig;
+use psyche_coordinator::RunState;
+use psyche_coordinator::WitnessProof;
+use psyche_coordinator::WAITING_FOR_MEMBERS_EXTRA_SECONDS;
+use psyche_core::ConstantLR;
+use psyche_core::LearningRateSchedule;
+use psyche_core::OptimizerDefinition;
+use psyche_solana_authorizer::logic::AuthorizationGrantorUpdateParams;
+use psyche_solana_coordinator::instruction::Witness;
+use psyche_solana_coordinator::logic::InitCoordinatorParams;
+use psyche_solana_coordinator::logic::JOIN_RUN_AUTHORIZATION_SCOPE;
+use psyche_solana_coordinator::ClientId;
+use psyche_solana_coordinator::CoordinatorAccount;
+use psyche_solana_tooling::create_memnet_endpoint::create_memnet_endpoint;
+use psyche_solana_tooling::get_accounts::get_coordinator_account_state;
+use psyche_solana_tooling::process_authorizer_instructions::process_authorizer_authorization_create;
+use psyche_solana_tooling::process_authorizer_instructions::process_authorizer_authorization_grantor_update;
+use psyche_solana_tooling::process_coordinator_instructions::process_coordinator_init;
+use psyche_solana_tooling::process_coordinator_instructions::process_coordinator_join_run;
+use psyche_solana_tooling::process_coordinator_instructions::process_coordinator_set_paused;
+use psyche_solana_tooling::process_coordinator_instructions::process_coordinator_tick;
+use psyche_solana_tooling::process_coordinator_instructions::process_coordinator_witness;
+use psyche_solana_tooling::process_coordinator_instructions::process_update;
+use solana_sdk::signature::Keypair;
+use solana_sdk::signer::Signer;
+
+#[tokio::test]
+pub async fn run() {
+    let mut endpoint = create_memnet_endpoint().await;
+
+    // Create payer key and fund it
+    let payer = Keypair::new();
+    endpoint
+        .process_airdrop(&payer.pubkey(), 10_000_000_000)
+        .await
+        .unwrap();
+
+    // Run constants
+    let main_authority = Keypair::new();
+    let join_authority = Keypair::new();
+    let client = Keypair::new();
+    let ticker = Keypair::new();
+    let warmup_time = 77;
+    let round_witness_time = 88;
+
+    // create the empty pre-allocated coordinator_account
+    let coordinator_account = endpoint
+        .process_system_new_exempt(
+            &payer,
+            CoordinatorAccount::space_with_discriminator(),
+            &psyche_solana_coordinator::ID,
+        )
+        .await
+        .unwrap();
+
+    // initialize the coordinator
+    let coordinator_instance = process_coordinator_init(
+        &mut endpoint,
+        &payer,
+        &coordinator_account,
+        InitCoordinatorParams {
+            run_id: "This is a random run id!".to_string(),
+            main_authority: main_authority.pubkey(),
+            join_authority: join_authority.pubkey(),
+        },
+    )
+    .await
+    .unwrap();
+
+    // verify that the run is in initialized state
+    assert_eq!(
+        get_coordinator_account_state(&mut endpoint, &coordinator_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .coordinator
+            .run_state,
+        RunState::Uninitialized
+    );
+
+    // update the coordinator's model
+    process_update(
+        &mut endpoint,
+        &payer,
+        &main_authority,
+        &coordinator_instance,
+        &coordinator_account,
+        None,
+        Some(CoordinatorConfig {
+            warmup_time,
+            cooldown_time: 999,
+            max_round_train_time: 888,
+            round_witness_time,
+            min_clients: 1,
+            init_min_clients: 1,
+            global_batch_size_start: 1,
+            global_batch_size_end: 1,
+            global_batch_size_warmup_tokens: 0,
+            verification_percent: 0,
+            witness_nodes: 1,
+            rounds_per_epoch: 10,
+            total_steps: 100,
+        }),
+        Some(Model::LLM(LLM {
+            architecture: LLMArchitecture::HfLlama,
+            checkpoint: Checkpoint::Dummy(HubRepo::dummy()),
+            max_seq_len: 4096,
+            data_type: LLMTrainingDataType::Pretraining,
+            data_location: LLMTrainingDataLocation::default(),
+            lr_schedule: LearningRateSchedule::Constant(ConstantLR::default()),
+            optimizer: OptimizerDefinition::Distro {
+                clip_grad_norm: None,
+                compression_decay: 1.0,
+                compression_topk: 1,
+                compression_chunk: 1,
+                quantize_1bit: false,
+                weight_decay: None,
+            },
+            cold_start_warmup_steps: 0,
+        })),
+        None, // no explicit progress
+    )
+    .await
+    .unwrap();
+
+    // Coordinator's state should now have changed
+    assert_eq!(
+        get_coordinator_account_state(&mut endpoint, &coordinator_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .coordinator
+            .run_state,
+        RunState::Uninitialized
+    );
+
+    // Generate the client key
+    let client_id = ClientId::new(client.pubkey(), Default::default());
+
+    // Add client to whitelist
+    let authorization = process_authorizer_authorization_create(
+        &mut endpoint,
+        &payer,
+        &join_authority,
+        &client.pubkey(),
+        JOIN_RUN_AUTHORIZATION_SCOPE,
+    )
+    .await
+    .unwrap();
+    process_authorizer_authorization_grantor_update(
+        &mut endpoint,
+        &payer,
+        &join_authority,
+        &authorization,
+        AuthorizationGrantorUpdateParams { active: true },
+    )
+    .await
+    .unwrap();
+
+    // Whitelisted with the wrong account, can't join
+    assert!(process_coordinator_join_run(
+        &mut endpoint,
+        &payer,
+        &payer,
+        &authorization,
+        &coordinator_instance,
+        &coordinator_account,
+        client_id
+    )
+    .await
+    .is_err());
+
+    // Whitelisted, can join
+    process_coordinator_join_run(
+        &mut endpoint,
+        &payer,
+        &client,
+        &authorization,
+        &coordinator_instance,
+        &coordinator_account,
+        client_id,
+    )
+    .await
+    .unwrap();
+
+    // Coordinator should still not be ready
+    assert_eq!(
+        get_coordinator_account_state(&mut endpoint, &coordinator_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .coordinator
+            .run_state,
+        RunState::Uninitialized
+    );
+
+    // Can't tick yet because paused
+    assert!(process_coordinator_tick(
+        &mut endpoint,
+        &payer,
+        &ticker,
+        &coordinator_instance,
+        &coordinator_account,
+    )
+    .await
+    .is_err());
+
+    // Unpause
+    process_coordinator_set_paused(
+        &mut endpoint,
+        &payer,
+        &main_authority,
+        &coordinator_instance,
+        &coordinator_account,
+        false,
+    )
+    .await
+    .unwrap();
+
+    // Rejoin run, should be a no-op
+    process_coordinator_join_run(
+        &mut endpoint,
+        &payer,
+        &client,
+        &authorization,
+        &coordinator_instance,
+        &coordinator_account,
+        client_id,
+    )
+    .await
+    .unwrap();
+
+    // Tick to transition from waiting for members to warmup
+    endpoint
+        .forward_clock_unix_timestamp(WAITING_FOR_MEMBERS_EXTRA_SECONDS)
+        .await
+        .unwrap();
+    process_coordinator_tick(
+        &mut endpoint,
+        &payer,
+        &ticker,
+        &coordinator_instance,
+        &coordinator_account,
+    )
+    .await
+    .unwrap();
+
+    // Coordinator should have changed
+    assert_eq!(
+        get_coordinator_account_state(&mut endpoint, &coordinator_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .coordinator
+            .run_state,
+        RunState::Warmup
+    );
+
+    // Tick from warmup to round train
+    endpoint
+        .forward_clock_unix_timestamp(warmup_time)
+        .await
+        .unwrap();
+    process_coordinator_tick(
+        &mut endpoint,
+        &payer,
+        &ticker,
+        &coordinator_instance,
+        &coordinator_account,
+    )
+    .await
+    .unwrap();
+
+    // Coordinator in train mode
+    let coordinator =
+        get_coordinator_account_state(&mut endpoint, &coordinator_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .coordinator;
+    assert_eq!(coordinator.run_state, RunState::RoundTrain);
+    assert_eq!(coordinator.current_round().unwrap().height, 0);
+    assert_eq!(coordinator.progress.step, 1);
+
+    // Check that only the right user can successfully send a witness
+    let witness = Witness {
+        proof: WitnessProof {
+            witness: true.into(),
+            position: 0,
+            index: 0,
+        },
+        participant_bloom: Default::default(),
+        broadcast_bloom: Default::default(),
+        broadcast_merkle: Default::default(),
+        metadata: Default::default(),
+    };
+    assert!(process_coordinator_witness(
+        &mut endpoint,
+        &payer,
+        &ticker,
+        &coordinator_instance,
+        &coordinator_account,
+        &witness,
+    )
+    .await
+    .is_err());
+    process_coordinator_witness(
+        &mut endpoint,
+        &payer,
+        &client,
+        &coordinator_instance,
+        &coordinator_account,
+        &witness,
+    )
+    .await
+    .unwrap();
+
+    // Coordinator state after witness should change
+    assert_eq!(
+        get_coordinator_account_state(&mut endpoint, &coordinator_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .coordinator
+            .run_state,
+        RunState::RoundWitness
+    );
+
+    // Tick from round witness back to round train should work
+    endpoint
+        .forward_clock_unix_timestamp(round_witness_time)
+        .await
+        .unwrap();
+    process_coordinator_tick(
+        &mut endpoint,
+        &payer,
+        &ticker,
+        &coordinator_instance,
+        &coordinator_account,
+    )
+    .await
+    .unwrap();
+
+    // Coordinator state after witness should change
+    assert_eq!(
+        get_coordinator_account_state(&mut endpoint, &coordinator_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .coordinator
+            .run_state,
+        RunState::RoundTrain
+    );
+}

--- a/architectures/decentralized/solana-tooling/tests/suites/memnet_treasurer_full_epoch.rs
+++ b/architectures/decentralized/solana-tooling/tests/suites/memnet_treasurer_full_epoch.rs
@@ -7,6 +7,7 @@ use psyche_coordinator::model::Model;
 use psyche_coordinator::model::LLM;
 use psyche_coordinator::CoordinatorConfig;
 use psyche_coordinator::WitnessProof;
+use psyche_coordinator::WAITING_FOR_MEMBERS_EXTRA_SECONDS;
 use psyche_core::ConstantLR;
 use psyche_core::LearningRateSchedule;
 use psyche_core::OptimizerDefinition;
@@ -50,6 +51,9 @@ pub async fn run() {
     let participant = Keypair::new();
     let client = Keypair::new();
     let ticker = Keypair::new();
+    let warmup_time = 77;
+    let round_witness_time = 33;
+    let cooldown_time = 42;
     let rounds_per_epoch = 4;
     let earned_point_per_epoch = 33;
 
@@ -191,10 +195,10 @@ pub async fn run() {
         RunUpdateParams {
             metadata: None,
             config: Some(CoordinatorConfig {
-                warmup_time: 1,
-                cooldown_time: 1,
-                max_round_train_time: 3,
-                round_witness_time: 1,
+                warmup_time,
+                cooldown_time,
+                max_round_train_time: 888,
+                round_witness_time,
                 min_clients: 1,
                 init_min_clients: 1,
                 global_batch_size_start: 1,
@@ -283,10 +287,11 @@ pub async fn run() {
     .await
     .unwrap();
 
-    // Pretend 10 second passed
-    endpoint.forward_clock_unix_timestamp(10).await.unwrap();
-
     // Tick to transition from waiting for members to warmup
+    endpoint
+        .forward_clock_unix_timestamp(WAITING_FOR_MEMBERS_EXTRA_SECONDS)
+        .await
+        .unwrap();
     process_coordinator_tick(
         &mut endpoint,
         &payer,
@@ -297,8 +302,11 @@ pub async fn run() {
     .await
     .unwrap();
 
-    // Tick to witness
-    endpoint.forward_clock_unix_timestamp(10).await.unwrap();
+    // Tick from warmup to train
+    endpoint
+        .forward_clock_unix_timestamp(warmup_time)
+        .await
+        .unwrap();
     process_coordinator_tick(
         &mut endpoint,
         &payer,
@@ -333,8 +341,11 @@ pub async fn run() {
         .await
         .unwrap();
 
-        // Tick from witness to train (or cooldown on the last one)
-        endpoint.forward_clock_unix_timestamp(2).await.unwrap();
+        // Tick from witness back next round train (or epoch cooldown after the last round)
+        endpoint
+            .forward_clock_unix_timestamp(round_witness_time)
+            .await
+            .unwrap();
         process_coordinator_tick(
             &mut endpoint,
             &payer,
@@ -360,8 +371,11 @@ pub async fn run() {
     .await
     .unwrap_err();
 
-    // Tick from cooldown to new epoch (should increment the earned)
-    endpoint.forward_clock_unix_timestamp(10).await.unwrap();
+    // Tick from cooldown to new epoch (should increment the earned points)
+    endpoint
+        .forward_clock_unix_timestamp(cooldown_time)
+        .await
+        .unwrap();
     process_coordinator_tick(
         &mut endpoint,
         &payer,

--- a/architectures/decentralized/solana-tooling/tests/suites/mod.rs
+++ b/architectures/decentralized/solana-tooling/tests/suites/mod.rs
@@ -1,5 +1,6 @@
 mod memnet_authorizer_full_cycle;
 mod memnet_coordinator_data_layout;
-mod memnet_coordinator_full_cycle;
+mod memnet_coordinator_full_round;
 mod memnet_coordinator_init_free;
+mod memnet_coordinator_rewards;
 mod memnet_treasurer_full_epoch;

--- a/shared/coordinator/src/coordinator.rs
+++ b/shared/coordinator/src/coordinator.rs
@@ -439,28 +439,18 @@ impl<T: NodeIdentity> Coordinator<T> {
         unix_timestamp: u64,
         random_seed: u64,
     ) -> std::result::Result<TickResult, CoordinatorError> {
-        let ret = match self.run_state {
+        match self.run_state {
             RunState::Uninitialized | RunState::Finished | RunState::Paused => {
                 Err(CoordinatorError::Halted)
             }
-            run_state => {
-                if run_state == RunState::WaitingForMembers {
-                    self.tick_waiting_for_members(new_clients, unix_timestamp)
-                } else if run_state == RunState::Cooldown {
-                    self.tick_cooldown(unix_timestamp)
-                } else {
-                    match run_state {
-                        RunState::Warmup => self.tick_warmup(unix_timestamp, random_seed),
-                        RunState::RoundTrain => self.tick_round_train(unix_timestamp),
-                        RunState::RoundWitness => {
-                            self.tick_round_witness(unix_timestamp, random_seed)
-                        }
-                        _ => unreachable!(),
-                    }
-                }
+            RunState::WaitingForMembers => {
+                self.tick_waiting_for_members(new_clients, unix_timestamp)
             }
-        }?;
-        Ok(ret)
+            RunState::Warmup => self.tick_warmup(unix_timestamp, random_seed),
+            RunState::RoundTrain => self.tick_round_train(unix_timestamp),
+            RunState::RoundWitness => self.tick_round_witness(unix_timestamp, random_seed),
+            RunState::Cooldown => self.tick_cooldown(unix_timestamp),
+        }
     }
 
     pub fn warmup_witness(
@@ -896,16 +886,22 @@ impl<T: NodeIdentity> Coordinator<T> {
             let height = self.current_round_unchecked().height;
             self.move_clients_to_exited(height);
 
+            // Read the pending clients
+            let mut pending_clients_ordered = Vec::with_capacity(pending_clients.len());
+            let mut pending_clients_unordered = HashSet::with_capacity(pending_clients.len());
+            for pending_client in pending_clients {
+                pending_clients_ordered.push(pending_client);
+                pending_clients_unordered.insert(pending_client);
+            }
+
             // Ensure at least one client in the previous epoch is present in pending_clients for the new epoch.
             // If all clients are no longer present we need to use a Hub checkpoint since there
             // will be no peers for P2P sharing.
-            let pending_clients: HashSet<_> = pending_clients.collect();
             let all_prev_clients_disconnected = !self
                 .epoch_state
                 .clients
                 .iter()
-                .any(|client| pending_clients.contains(&client.id));
-
+                .any(|client| pending_clients_unordered.contains(&client.id));
             if all_prev_clients_disconnected {
                 let Model::LLM(llm) = &mut self.model;
                 if let Checkpoint::P2P(hub_repo) = llm.checkpoint {
@@ -921,7 +917,7 @@ impl<T: NodeIdentity> Coordinator<T> {
             self.epoch_state
                 .clients
                 .extend(
-                    pending_clients
+                    pending_clients_ordered
                         .into_iter()
                         .take(SOLANA_MAX_NUM_CLIENTS)
                         .map(|x| Client::new(*x)),

--- a/shared/coordinator/src/lib.rs
+++ b/shared/coordinator/src/lib.rs
@@ -15,6 +15,7 @@ pub use coordinator::{
     CoordinatorProgress, HealthChecks, Round, RunState, TickResult, Witness, WitnessBloom,
     WitnessEvalResult, WitnessMetadata, BLOOM_FALSE_RATE, NUM_STORED_ROUNDS,
     SOLANA_MAX_NUM_CLIENTS, SOLANA_MAX_NUM_WITNESSES, SOLANA_MAX_STRING_LEN,
+    WAITING_FOR_MEMBERS_EXTRA_SECONDS,
 };
 pub use data_selection::{
     assign_data_for_state, get_batch_ids_for_node, get_batch_ids_for_round, get_data_index_for_step,


### PR DESCRIPTION
## Summary

Giving another shot to fixing the reward distribution logic from the revert PR: https://github.com/PsycheFoundation/psyche/pull/116

## Details

Retrying by not using a `HashSet` during reward distribution but instead keeping original client ordering when initiating the epoch's client list (so that the reward distribution can just do a sequential scan on the client list)