### PR TITLE
P2P retry model sharing improvements

### DIFF
--- a/shared/client/src/client.rs
+++ b/shared/client/src/client.rs
@@ -9,9 +9,10 @@ use psyche_coordinator::{Commitment, CommitteeSelection, Coordinator, RunState};
 use psyche_core::NodeIdentity;
 use psyche_metrics::{ClientMetrics, ClientRoleInRound, PeerConnection};
 use psyche_network::{
-    allowlist, param_request_task, raw_p2p_verify, AuthenticatableIdentity, BlobTicket,
-    DownloadComplete, DownloadType, ModelRequestType, NetworkConnection, NetworkEvent,
-    NetworkTUIState, Networkable, NodeAddr, NodeId, SharableModel, TransmittableDownload,
+    allowlist, param_request_task, raw_p2p_verify, router::Router, AuthenticatableIdentity,
+    BlobTicket, DownloadComplete, DownloadType, ModelRequestType, NetworkConnection, NetworkEvent,
+    NetworkTUIState, Networkable, NodeAddr, NodeId, PublicKey, SharableModel,
+    TransmittableDownload,
 };
 use psyche_watcher::{Backend, BackendWatcher};
 use tokenizers::Tokenizer;
@@ -42,7 +43,7 @@ pub struct Client<T: NodeIdentity, A: AuthenticatableIdentity, B: Backend<T> + '
     _t: PhantomData<(T, A, B)>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct DownloadRetryInfo {
     retries: usize,
     retry_time: Option<Instant>,
@@ -103,7 +104,8 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                     mpsc::unbounded_channel();
                 let (tx_broadcast_finished, mut rx_broadcast_finished) = mpsc::unbounded_channel();
 
-                let max_concurrent_downloads = init_config.max_concurrent_parameter_requests;
+                let max_concurrent_parameter_requests =
+                    init_config.max_concurrent_parameter_requests;
 
                 let mut run = RunManager::<T, A>::new(RunInitConfigAndIO {
                     init_config,
@@ -120,9 +122,11 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                     tx_broadcast_finished,
                 });
 
-                let mut retried_downloads: HashMap<psyche_network::Hash, DownloadRetryInfo> =
-                    HashMap::new();
+                let retried_downloads: Arc<
+                    Mutex<HashMap<psyche_network::Hash, DownloadRetryInfo>>,
+                > = Arc::new(Mutex::new(HashMap::new()));
                 let mut sharable_model = SharableModel::empty();
+
                 let mut broadcasts = vec![];
                 let mut broadcasts_rebroadcast_index = 0;
                 let mut sharing_downloadable_interval = interval(REBROADCAST_SHAREABLE);
@@ -263,7 +267,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                     }) => {
                                         let _ = trace_span!("NetworkEvent::DownloadComplete", hash = %hash).entered();
                                         metrics.record_download_completed(hash, from);
-                                        if retried_downloads.remove(&hash).is_some() {
+                                        if retried_downloads.lock().await.remove(&hash).is_some() {
                                             debug!("Successfully downloaded previously failed blob {}", hex::encode(hash));
                                         }
                                         match download_data {
@@ -288,50 +292,60 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                     NetworkEvent::DownloadFailed(dl) => {
                                         let _ = trace_span!("NetworkEvent::DownloadFailed", error=%dl.error).entered();
                                         let hash = dl.blob_ticket.hash();
-                                        let info = retried_downloads.get(&hash);
-                                        let retries = info.map(|i| i.retries).unwrap_or(0);
+                                        let retries = retried_downloads.lock().await.get(&hash).map(|i| i.retries).unwrap_or(0);
 
                                         if retries >= MAX_DOWNLOAD_RETRIES {
                                             metrics.record_download_perma_failed(hash);
                                             warn!("Download failed (not retrying): {}", dl.error);
-                                            retried_downloads.remove(&hash);
+                                            retried_downloads.lock().await.remove(&hash);
                                         } else {
                                             metrics.record_download_failed(hash);
                                             let backoff_duration = DOWNLOAD_RETRY_BACKOFF_BASE.mul_f32(2_f32.powi(retries as i32));
                                             let retry_time = Some(std::time::Instant::now() + backoff_duration);
 
                                             info!(
-                                                "Download failed (will retry in {:?}): {}",
+                                                "Download failed for blob with hash {hash} (will retry in {:?}): {}",
                                                 backoff_duration,
                                                 dl.error
                                             );
 
-                                            let blob_ticket_to_retry = if let DownloadType::ModelSharing(request_type) = dl.download_type.clone() {
-                                                    let me = NodeId::from_bytes(identity.get_p2p_public_key())?;
-                                                    let Some(coordinator_state) = watcher.coordinator_state() else {
-                                                        bail!("Coordinator state not yet registered, nothing to do. Try joining the run again.");
-                                                    };
-                                                    let mut peer_ids: Vec<NodeId> = participating_node_ids(&coordinator_state).into_iter().filter(|peer_id| peer_id != &me).collect();
-                                                    peer_ids.retain(|a| a != &dl.blob_ticket.node_addr().node_id);
-                                                    let new_blob_ticket = get_blob_ticket_to_download(&p2p, peer_ids, &param_requests_cancel_token, request_type.clone()).await?;
-
-                                                    // We remove the old hash because we're getting the blob from a new peer that has its own version of the model parameter or config blob
-                                                    retried_downloads.remove(&hash);
-                                                    new_blob_ticket
+                                            let param_requests_cancel_token = param_requests_cancel_token.clone();
+                                            let router = p2p.router();
+                                            let peer_ids = if let Some(state) = run.coordinator_state() {
+                                                participating_node_ids(state)
                                             } else {
-                                                dl.blob_ticket
+                                                bail!("Error getting the state of the coordinator");
                                             };
 
-                                            retried_downloads.insert(blob_ticket_to_retry.hash(), DownloadRetryInfo {
-                                                retries: retries + 1,
-                                                retry_time,
-                                                ticket: blob_ticket_to_retry,
+                                            let retried_downloads = retried_downloads.clone();
+                                            let peer_cycle = sharable_model.peer_cycle.clone();
+                                            let errored_peers = sharable_model.errored_peers.clone();
+                                            tokio::spawn(async move {
+                                                let blob_ticket_to_retry = if let DownloadType::ModelSharing(request_type) = dl.download_type.clone() {
+                                                    match get_blob_ticket_to_download(router, &param_requests_cancel_token, request_type.clone(), peer_cycle, errored_peers, peer_ids.len()).await {
+                                                        Ok(new_blob_ticket) => {
+                                                            // We remove the old hash because we're getting the blob from a new peer that has its own version of the model parameter or config blob
+                                                            retried_downloads.lock().await.remove(&hash);
+                                                            new_blob_ticket
+                                                        }
+                                                        Err(e) => {
+                                                            warn!("There was an error traying to get a new blob ticket to retry: {e}, will retry the same one");
+                                                            dl.blob_ticket
+                                                        }
+                                                    }
+                                                } else {
+                                                    dl.blob_ticket
+                                                };
+                                                retried_downloads.lock().await.insert(blob_ticket_to_retry.hash(), DownloadRetryInfo {
+                                                    retries: retries + 1,
+                                                    retry_time,
+                                                    ticket: blob_ticket_to_retry,
                                                 tag: dl.tag,
                                                 r#type: dl.download_type,
                                             });
-
-                                        }
+                                        });
                                     }
+                                }
                                     NetworkEvent::ParameterRequest(parameter_name, protocol_req_tx) => {
                                         // TODO: We should validate that the parameter is requested while we are in RunState::Warmup.
                                         trace!("NetworkEvent::ParameterRequest({parameter_name})");
@@ -437,6 +451,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
 
                         _ = retry_check_interval.tick() => {
                             let now = Instant::now();
+                            let mut retried_downloads = retried_downloads.lock().await;
                             let pending_retries: Vec<(psyche_network::Hash, BlobTicket, u32, DownloadType)> = retried_downloads.iter()
                                 .filter(|(_, info)| info.retry_time.map(|retry_time| now >= retry_time).unwrap_or(false) && info.retries <= MAX_DOWNLOAD_RETRIES)
                                 .map(|(hash, info)| (*hash, info.ticket.clone(), info.tag, info.r#type.clone()))
@@ -502,19 +517,19 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                             }
                             let num_peers = peer_ids.len();
                             let param_requests_cancel_token = param_requests_cancel_token.clone();
+                            let peer_cycle = sharable_model.peer_cycle.clone();
+                            let errored_peers = sharable_model.errored_peers.clone();
                             let handle: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
                                 // We use std mutex implementation here and call `.unwrap()` when acquiring the lock since there
                                 // is no chance of mutex poisoning; locks are acquired only to insert or remove items from them
                                 // and dropped immediately
                                 let parameter_blob_tickets = Arc::new(std::sync::Mutex::new(Vec::new()));
-                                let errored_peers = Arc::new(std::sync::Mutex::new(HashMap::new()));
-                                let peer_cycle = Arc::new(Mutex::new(VecDeque::from(peer_ids)));
                                 let mut request_handles = Vec::new();
 
                                 for param_name in param_names {
-                                    let router = router.clone();
-                                    let errored_peers = errored_peers.clone();
                                     let peer_cycle = peer_cycle.clone();
+                                    let errored_peers = errored_peers.clone();
+                                    let router = router.clone();
 
                                     let request_handle = tokio::spawn(
                                         param_request_task(
@@ -530,7 +545,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
 
                                     // Check if we reached the max number of concurrent requests, and if that is the case,
                                     // await for all of them to complete and start downloading the blobs
-                                    if request_handles.len() == max_concurrent_downloads - 1 {
+                                    if request_handles.len() == max_concurrent_parameter_requests - 1 {
                                         let mut max_concurrent_request_futures = std::mem::take(&mut request_handles);
                                         max_concurrent_request_futures.push(request_handle);
                                         join_all(max_concurrent_request_futures).await;
@@ -569,9 +584,8 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                 .filter(|peer_id| peer_id != &me)
                                 .collect();
 
-                            let config_blob_ticket = get_blob_ticket_to_download(&p2p, peer_ids, &param_requests_cancel_token, ModelRequestType::Config).await?;
-
-                            // tokio::time::sleep(Duration::from_secs(5)).await;
+                            sharable_model.peer_cycle = Arc::new(Mutex::new(VecDeque::from(peer_ids.clone())));
+                            let config_blob_ticket = get_blob_ticket_to_download(p2p.router(), &param_requests_cancel_token, ModelRequestType::Config, sharable_model.peer_cycle.clone(), sharable_model.errored_peers.clone(), peer_ids.len()).await?;
 
                             let kind = DownloadType::ModelSharing(ModelRequestType::Config);
                             metrics.record_download_started(config_blob_ticket.hash(), kind.kind());
@@ -787,18 +801,15 @@ fn all_node_addrs_shuffled<T: NodeIdentity>(state: &Coordinator<T>) -> Vec<NodeA
 }
 
 async fn get_blob_ticket_to_download(
-    p2p: &NC,
-    peer_ids: Vec<NodeId>,
+    router: Arc<Router>,
     param_requests_cancel_token: &CancellationToken,
     request_type: ModelRequestType,
+    peer_cycle: Arc<Mutex<VecDeque<NodeId>>>,
+    errored_peers: Arc<std::sync::Mutex<HashMap<PublicKey, usize>>>,
+    num_peers: usize,
 ) -> Result<BlobTicket, anyhow::Error> {
-    let router = p2p.router();
     // initialize variables to request model config
     let config_blob_tickets = Arc::new(std::sync::Mutex::new(Vec::with_capacity(1)));
-    let errored_peers = Arc::new(std::sync::Mutex::new(HashMap::new()));
-    let num_peers = peer_ids.len();
-    let peer_cycle = Arc::new(Mutex::new(VecDeque::from(peer_ids)));
-
     if num_peers == 0 {
         return Err(anyhow::anyhow!("No peers available to request the model"));
     }

--- a/shared/network/src/download_manager.rs
+++ b/shared/network/src/download_manager.rs
@@ -385,7 +385,7 @@ impl<D: Networkable + Send + 'static> DownloadManager<D> {
             })) => {
                 downloads.swap_remove(index);
                 warn!(
-                    "Download error, removing it. idx {index}, hash {}: {:?}",
+                    "Download error, removing it. idx {index}, hash {}: {}",
                     blob_ticket.hash(),
                     error
                 );

--- a/shared/network/src/download_manager.rs
+++ b/shared/network/src/download_manager.rs
@@ -385,8 +385,9 @@ impl<D: Networkable + Send + 'static> DownloadManager<D> {
             })) => {
                 downloads.swap_remove(index);
                 warn!(
-                    "Download error, removing it. idx {index}, hash {}: {}",
+                    "Download error, removing it. idx {index}, hash {}, node provider {}: {}",
                     blob_ticket.hash(),
+                    blob_ticket.node_addr().node_id,
                     error
                 );
             }

--- a/shared/network/src/lib.rs
+++ b/shared/network/src/lib.rs
@@ -53,7 +53,7 @@ mod download_manager;
 mod local_discovery;
 mod p2p_model_sharing;
 mod peer_list;
-mod router;
+pub mod router;
 mod serde;
 mod serializable_kind;
 mod serializable_tensor;
@@ -384,18 +384,20 @@ where
         let ticket_hash = ticket.hash();
         let additional_peers_to_try = match download_type.clone() {
             DownloadType::DistroResult(peers) => peers,
-            DownloadType::ModelSharing(_) => vec![],
+            DownloadType::ModelSharing(_) => {
+                vec![]
+            }
         };
         let (tx, rx) = mpsc::unbounded_channel();
 
         self.state.currently_sharing_blobs.insert(ticket_hash);
         self.state.blob_tags.insert((tag, ticket_hash));
-        self.download_manager.add(ticket, tag, rx, download_type);
+        self.download_manager
+            .add(ticket, tag, rx, download_type.clone());
 
-        debug!(name: "blob_download_start", hash = ticket_hash.fmt_short(), "started downloading blob {}", ticket_hash.fmt_short());
+        debug!(name: "blob_download_start", hash = ticket_hash.fmt_short(), "started downloading blob {}", ticket_hash);
 
         let blobs_client = self.blobs.client().clone();
-
         tokio::spawn(async move {
             let download_opts = DownloadOptions {
                 format: BlobFormat::Raw,

--- a/shared/network/src/lib.rs
+++ b/shared/network/src/lib.rs
@@ -628,9 +628,12 @@ pub async fn request_model(
 
     // Receive parameter value blob ticket
     let parameter_blob_ticket_bytes = recv.read_to_end(16384).await?;
-    let parameter_blob_ticket: Result<BlobTicket, SharableModelError> =
-        postcard::from_bytes(&parameter_blob_ticket_bytes)?;
-    parameter_blob_ticket.with_context(|| "Error parsing model parameter blob ticket".to_string())
+    let parameter_blob_ticket: Result<Result<BlobTicket, SharableModelError>, postcard::Error> =
+        postcard::from_bytes(&parameter_blob_ticket_bytes);
+    let result = parameter_blob_ticket
+        .with_context(|| "Error parsing model parameter blob ticket".to_string())?;
+
+    result.map_err(|e| anyhow!("Error received from peer: {e}"))
 }
 
 fn parse_gossip_event<BroadcastMessage: Networkable>(

--- a/shared/network/src/p2p_model_sharing.rs
+++ b/shared/network/src/p2p_model_sharing.rs
@@ -1,12 +1,16 @@
 use anyhow::Result;
+use iroh::PublicKey;
 use iroh::{endpoint::Connection, protocol::ProtocolHandler};
 use iroh_blobs::ticket::BlobTicket;
 use psyche_core::BoxedFuture;
+use std::collections::VecDeque;
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::io::{Cursor, Write};
+use std::sync::Arc;
 use tch::Tensor;
 use thiserror::Error;
 use tokenizers::Tokenizer;
+use tokio::sync::Mutex;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, trace};
@@ -144,6 +148,13 @@ pub struct SharableModel {
     config_and_tokenizer_ticket: Option<BlobTicket>,
     pub tx_model_config_response: Option<oneshot::Sender<(String, Tokenizer)>>,
     tx_params_response: Option<oneshot::Sender<HashMap<String, Tensor>>>,
+
+    /// List of peers that are sharing the model parameters and config.
+    /// We cycled through this list to request parameters from them.
+    pub peer_cycle: Arc<Mutex<VecDeque<PublicKey>>>,
+    /// A map of peers that have errored while sharing parameters.
+    /// If a peer has errored more than a certain threshold, it will be removed from the cycle.
+    pub errored_peers: Arc<std::sync::Mutex<HashMap<PublicKey, usize>>>,
 }
 
 // These impls are methods called by both the sharing model peers and the ones
@@ -159,6 +170,8 @@ impl SharableModel {
             tokenizer_config: None,
             config_and_tokenizer_ticket: None,
             tx_model_config_response: None,
+            errored_peers: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            peer_cycle: Arc::new(Mutex::new(VecDeque::new())),
         }
     }
 }


### PR DESCRIPTION
This PR makes some improvements on the model sharing retries and add some logs to actually check the errors we're getting about `No providers found` trying to download paramaters from other peers.
Specifically the improvements are:
- Avoid locking the client loop trying to retry a failed download.
- Use the `peer_cycle` and the `errored_peers` as a shared result. That way we avoid using different peers states for the retry and the main paramter sharing logic.