### PR TITLE
Do not panic on wandb failure

### DIFF
--- a/shared/client/src/lib.rs
+++ b/shared/client/src/lib.rs
@@ -15,7 +15,7 @@ pub use state::{
 pub use testing::IntegrationTestLogMarker;
 pub use tui::{ClientTUI, ClientTUIState};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WandBInfo {
     pub project: String,
     pub run: String,


### PR DESCRIPTION
The application will continue and we log an error to the console, in the future we might want to retry the operating in a separate thread in the background or similar, but for now this is the simplest solution.

Originally we tried to do the retry logic but we had to made some functions async and it got messy really quickly, we can take a look at it in the future if we deem it important.

Solves #98 

