### PR TITLE
metrics: reduce cardinality in neighbors

### DIFF
--- a/shared/client/src/client.rs
+++ b/shared/client/src/client.rs
@@ -256,7 +256,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                                 metrics.record_apply_message_failure(broadcast_step, from, broadcast_kind);
                                             }
                                         } else {
-                                            warn!("Got broadcast from unknown client {}", from);
+                                            trace!("Got broadcast from unknown client {}", from);
                                             metrics.record_apply_message_failure(broadcast_step, from, broadcast_kind);
                                         }
                                     }

--- a/shared/metrics/src/lib.rs
+++ b/shared/metrics/src/lib.rs
@@ -326,10 +326,8 @@ impl ClientMetrics {
     pub fn update_p2p_gossip_neighbors(&self, neighbors: &[impl Display]) {
         let num_neighbors = neighbors.len() as u64;
         let neighbor_ids = neighbors.iter().map(|p| p.to_string()).collect::<Vec<_>>();
-        self.gossip_neighbors.record(
-            num_neighbors,
-            &[KeyValue::new("peers", neighbor_ids.join(","))],
-        );
+        debug!(name: "gossip_neighbors", neighbors =  neighbor_ids.join(","));
+        self.gossip_neighbors.record(num_neighbors, &[]);
         self.tcp_metrics.lock().unwrap().gossip_neighbors = neighbor_ids;
     }
 


### PR DESCRIPTION
this happens when someone is kicked but their client is still running