### PR TITLE
New retry logic for model sharing process over P2P

### DIFF
--- a/shared/client/src/client.rs
+++ b/shared/client/src/client.rs
@@ -9,10 +9,10 @@ use psyche_coordinator::{Commitment, CommitteeSelection, Coordinator, RunState};
 use psyche_core::NodeIdentity;
 use psyche_metrics::{ClientMetrics, ClientRoleInRound, PeerConnection};
 use psyche_network::{
-    allowlist, param_request_task, raw_p2p_verify, router::Router, AuthenticatableIdentity,
-    BlobTicket, DownloadComplete, DownloadRetryInfo, DownloadType, ModelRequestType,
-    NetworkConnection, NetworkEvent, NetworkTUIState, Networkable, NodeAddr, NodeId,
-    PeerManagerHandle, RetriedDownloadsHandle, SharableModel, TransmittableDownload,
+    allowlist, blob_ticket_param_request_task, raw_p2p_verify, router::Router,
+    AuthenticatableIdentity, BlobTicket, DownloadComplete, DownloadRetryInfo, DownloadType,
+    ModelRequestType, NetworkConnection, NetworkEvent, NetworkTUIState, Networkable, NodeAddr,
+    NodeId, PeerManagerHandle, RetriedDownloadsHandle, SharableModel, TransmittableDownload,
     MAX_DOWNLOAD_RETRIES,
 };
 use psyche_watcher::{Backend, BackendWatcher};
@@ -32,7 +32,7 @@ use tokio::{
     time::interval,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, trace, trace_span, warn};
+use tracing::{debug, error, info, trace, trace_span, warn};
 
 pub type TUIStates = (ClientTUIState, NetworkTUIState);
 
@@ -49,8 +49,8 @@ const DOWNLOAD_RETRY_BACKOFF_BASE: Duration = Duration::from_secs(2);
 const DOWNLOAD_RETRY_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 const OPPROTUNISTIC_WITNESS_INTERVAL: Duration = Duration::from_millis(500);
 const CHECK_CONNECTION_INTERVAL: Duration = Duration::from_secs(10);
-const MAX_ERRORS_PER_PEER: usize = 2;
-const MAX_RETRIES_PER_PEER: usize = 5;
+const MAX_ERRORS_PER_PEER: u8 = 3;
+const MAX_RETRIES_PER_PEER: u8 = 5;
 
 impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'static>
     Client<T, A, B>
@@ -121,6 +121,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                 let peer_manager = Arc::new(PeerManagerHandle::new(
                     MAX_ERRORS_PER_PEER,
                     MAX_RETRIES_PER_PEER,
+                    param_requests_cancel_token.clone(),
                 ));
 
                 let mut broadcasts = vec![];
@@ -293,9 +294,10 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                         match dl.download_type {
                                             DownloadType::ModelSharing(request_type) => {
                                                 metrics.record_download_failed();
-                                                let backoff_duration = DOWNLOAD_RETRY_BACKOFF_BASE.mul_f32(2_f32.powi(retries as i32)).min(Duration::from_secs(16));
+                                                // We often get an error after some time in the iroh-blobs side so we use the base backoff to retry faster.
+                                                let backoff_duration = DOWNLOAD_RETRY_BACKOFF_BASE;
                                                 let retry_time = Some(std::time::Instant::now() + backoff_duration);
-                                                peer_manager.report_retry_error(dl.blob_ticket.node_addr().node_id);
+                                                peer_manager.report_blob_ticket_download_error(dl.blob_ticket.node_addr().node_id);
 
                                                 info!(
                                                     "Model Sharing download failed {} time/s (will retry in {:?}): {}",
@@ -306,8 +308,9 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                                 let router = p2p.router().clone();
                                                 let peer_manager = peer_manager.clone();
                                                 let retried_downloads = retried_downloads.clone();
+                                                let param_requests_cancel_token = param_requests_cancel_token.clone();
                                                 tokio::spawn(async move {
-                                                    let blob_ticket_to_retry = if let Ok(new_blob_ticket) = get_blob_ticket_to_download(router.clone(), request_type, peer_manager.clone()).await {
+                                                    let blob_ticket_to_retry = if let Ok(new_blob_ticket) = get_blob_ticket_to_download(router.clone(), request_type, peer_manager.clone(), param_requests_cancel_token).await {
                                                         // We remove the old hash because we're getting the blob from a new peer that has its own version of the model parameter or config blob
                                                         retried_downloads.remove(hash).await;
                                                         new_blob_ticket
@@ -522,6 +525,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                             let router = p2p.router();
 
                             let peer_manager = peer_manager.clone();
+                            let param_requests_cancel_token = param_requests_cancel_token.clone();
                             let handle: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
                                 // We use std mutex implementation here and call `.unwrap()` when acquiring the lock since there
                                 // is no chance of mutex poisoning; locks are acquired only to insert or remove items from them
@@ -534,11 +538,12 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                     let router = router.clone();
 
                                     let request_handle = tokio::spawn(
-                                        param_request_task(
+                                        blob_ticket_param_request_task(
                                             ModelRequestType::Parameter(param_name),
                                             router,
                                             parameter_blob_tickets.clone(),
                                             peer_manager.clone(),
+                                            param_requests_cancel_token.clone()
                                         )
                                     );
 
@@ -547,6 +552,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                     if request_handles.len() == max_concurrent_parameter_requests - 1 {
                                         let mut max_concurrent_request_futures = std::mem::take(&mut request_handles);
                                         max_concurrent_request_futures.push(request_handle);
+                                        // We don't care about the errors because we are already handling them inside the task
                                         join_all(max_concurrent_request_futures).await;
                                         let current_parameter_blob_tickets: Vec<(BlobTicket, ModelRequestType)> = {
                                             let mut parameter_blob_tickets_lock = parameter_blob_tickets.lock().unwrap();
@@ -587,9 +593,13 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                             peer_manager.set_peers(peer_ids);
                             let router = p2p.router().clone();
                             let tx_config_download = tx_config_download.clone();
+                            let param_requests_cancel_token = param_requests_cancel_token.clone();
                             tokio::spawn(async move {
-                                let config_blob_ticket = get_blob_ticket_to_download(router.clone(), ModelRequestType::Config, peer_manager).await.expect("Failed to get config blob ticket");
-                                tx_config_download.send(config_blob_ticket).expect("Failed to send config blob ticket");
+                                if let Ok(config_blob_ticket) = get_blob_ticket_to_download(router.clone(), ModelRequestType::Config, peer_manager, param_requests_cancel_token).await {
+                                    tx_config_download.send(config_blob_ticket).expect("Failed to send config blob ticket");
+                                } else {
+                                    error!("Error getting the config blob ticket, we'll not proceed with the download");
+                                }
                             });
                         }
                         Some(param_blob_tickets) = rx_params_download.recv() => {
@@ -809,16 +819,18 @@ async fn get_blob_ticket_to_download(
     router: Arc<Router>,
     request_type: ModelRequestType,
     peer_manager: Arc<PeerManagerHandle>,
+    cancellation_token: CancellationToken,
 ) -> Result<BlobTicket, anyhow::Error> {
     let blob_ticket = Arc::new(std::sync::Mutex::new(Vec::with_capacity(1)));
 
-    param_request_task(
+    blob_ticket_param_request_task(
         request_type.clone(),
         router,
         blob_ticket.clone(),
         peer_manager,
+        cancellation_token.clone(),
     )
-    .await?;
+    .await;
 
     let ticket_result = {
         let blob_ticket_lock = blob_ticket.lock().unwrap();

--- a/shared/client/src/client.rs
+++ b/shared/client/src/client.rs
@@ -50,6 +50,7 @@ const DOWNLOAD_RETRY_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 const OPPROTUNISTIC_WITNESS_INTERVAL: Duration = Duration::from_millis(500);
 const CHECK_CONNECTION_INTERVAL: Duration = Duration::from_secs(10);
 const MAX_ERRORS_PER_PEER: usize = 2;
+const MAX_RETRIES_PER_PEER: usize = 5;
 
 impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'static>
     Client<T, A, B>
@@ -117,7 +118,10 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
 
                 let retried_downloads = RetriedDownloadsHandle::new();
                 let mut sharable_model = SharableModel::empty();
-                let peer_manager = Arc::new(PeerManagerHandle::new(MAX_ERRORS_PER_PEER));
+                let peer_manager = Arc::new(PeerManagerHandle::new(
+                    MAX_ERRORS_PER_PEER,
+                    MAX_RETRIES_PER_PEER,
+                ));
 
                 let mut broadcasts = vec![];
                 let mut broadcasts_rebroadcast_index = 0;
@@ -284,47 +288,67 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                         let _ = trace_span!("NetworkEvent::DownloadFailed", error=%dl.error).entered();
                                         let hash = dl.blob_ticket.hash();
                                         let retries = retried_downloads.get(hash).await.map(|i| i.retries).unwrap_or(0);
+                                        let download_type_clone = dl.download_type.clone();
 
-                                        if retries >= MAX_DOWNLOAD_RETRIES {
-                                            metrics.record_download_perma_failed();
-                                            warn!("Download failed (not retrying): {}", dl.error);
-                                            retried_downloads.remove(hash).await;
-                                        } else {
-                                            metrics.record_download_failed();
-                                            let backoff_duration = DOWNLOAD_RETRY_BACKOFF_BASE.mul_f32(2_f32.powi(retries as i32));
-                                            let retry_time = Some(std::time::Instant::now() + backoff_duration);
+                                        match dl.download_type {
+                                            DownloadType::ModelSharing(request_type) => {
+                                                metrics.record_download_failed();
+                                                let backoff_duration = DOWNLOAD_RETRY_BACKOFF_BASE.mul_f32(2_f32.powi(retries as i32)).min(Duration::from_secs(16));
+                                                let retry_time = Some(std::time::Instant::now() + backoff_duration);
+                                                peer_manager.report_retry_error(dl.blob_ticket.node_addr().node_id);
 
-                                            info!(
-                                                "Download failed (will retry in {:?}): {}",
-                                                backoff_duration,
-                                                dl.error
-                                            );
-                                            let router = p2p.router().clone();
-                                            let peer_manager = peer_manager.clone();
-                                            let retried_downloads = retried_downloads.clone();
-                                            tokio::spawn(async move {
-                                                let blob_ticket_to_retry = if let DownloadType::ModelSharing(request_type) = dl.download_type.clone() {
-                                                        if let Ok(new_blob_ticket) = get_blob_ticket_to_download(router.clone(), request_type.clone(), peer_manager.clone()).await {
-                                                            // We remove the old hash because we're getting the blob from a new peer that has its own version of the model parameter or config blob
-                                                            retried_downloads.remove(hash).await;
-                                                            new_blob_ticket
-                                                        } else {
-                                                            dl.blob_ticket
-                                                        }
+                                                info!(
+                                                    "Model Sharing download failed {} time/s (will retry in {:?}): {}",
+                                                    retries + 1,
+                                                    backoff_duration,
+                                                    dl.error
+                                                );
+                                                let router = p2p.router().clone();
+                                                let peer_manager = peer_manager.clone();
+                                                let retried_downloads = retried_downloads.clone();
+                                                tokio::spawn(async move {
+                                                    let blob_ticket_to_retry = if let Ok(new_blob_ticket) = get_blob_ticket_to_download(router.clone(), request_type, peer_manager.clone()).await {
+                                                        // We remove the old hash because we're getting the blob from a new peer that has its own version of the model parameter or config blob
+                                                        retried_downloads.remove(hash).await;
+                                                        new_blob_ticket
+                                                    } else {
+                                                        dl.blob_ticket
+                                                    };
 
-                                                } else {
-                                                    dl.blob_ticket
-                                                };
-
-                                            retried_downloads.insert(DownloadRetryInfo {
-                                                retries: retries + 1,
-                                                retry_time,
-                                                ticket: blob_ticket_to_retry,
-                                                tag: dl.tag,
-                                                r#type: dl.download_type,
+                                                    retried_downloads.insert(DownloadRetryInfo {
+                                                        retries: retries + 1,
+                                                        retry_time,
+                                                        ticket: blob_ticket_to_retry,
+                                                        tag: dl.tag,
+                                                        r#type: download_type_clone,
+                                                    });
                                             });
-                                        });
-                                    }
+                                        }
+                                            DownloadType::DistroResult(_) => {
+                                                if retries >= MAX_DOWNLOAD_RETRIES {
+                                                    metrics.record_download_perma_failed();
+                                                    warn!("Distro result download failed (not retrying): {}", dl.error);
+                                                    retried_downloads.remove(hash).await;
+                                                } else {
+                                                    metrics.record_download_failed();
+                                                    let backoff_duration = DOWNLOAD_RETRY_BACKOFF_BASE.mul_f32(2_f32.powi(retries as i32));
+                                                    let retry_time = Some(std::time::Instant::now() + backoff_duration);
+
+                                                    info!(
+                                                        "Distro result download failed (will retry in {:?}): {}",
+                                                        backoff_duration,
+                                                        dl.error
+                                                    );
+                                                    retried_downloads.insert(DownloadRetryInfo {
+                                                        retries: retries + 1,
+                                                        retry_time,
+                                                        ticket: dl.blob_ticket,
+                                                        tag: dl.tag,
+                                                        r#type: dl.download_type,
+                                                    });
+                                                }
+                                            }
+                                        }
                                     }
                                     NetworkEvent::ParameterRequest(parameter_name, protocol_req_tx) => {
                                         // TODO: We should validate that the parameter is requested while we are in RunState::Warmup.

--- a/shared/network/src/p2p_model_sharing.rs
+++ b/shared/network/src/p2p_model_sharing.rs
@@ -14,7 +14,8 @@ use tokio::sync::{
     oneshot,
 };
 use tokio::task::JoinHandle;
-use tracing::{debug, trace, warn};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, trace, warn};
 
 use crate::{NetworkConnection, Networkable, TransmittableDownload};
 
@@ -36,24 +37,28 @@ enum PeerCommand {
     ReportSuccess {
         peer_id: NodeId,
     },
-    ReportError {
+    ReportBlobTicketRequestError {
         peer_id: NodeId,
     },
-    ReportRetryError {
+    ReportBlobTicketDownloadError {
         peer_id: NodeId,
     },
 }
 
 impl PeerManagerHandle {
-    pub fn new(max_errors_per_peer: usize, max_retries_per_peer: usize) -> Self {
+    pub fn new(
+        max_errors_per_peer: u8,
+        max_retries_per_peer: u8,
+        cancellation_token: CancellationToken,
+    ) -> Self {
         let (peer_tx, peer_rx) = mpsc::unbounded_channel();
 
         // Spawn the peer manager actor
         tokio::spawn(peer_manager_actor(
             peer_rx,
-            vec![],
             max_errors_per_peer,
             max_retries_per_peer,
+            cancellation_token,
         ));
 
         Self { peer_tx }
@@ -80,27 +85,27 @@ impl PeerManagerHandle {
         reply_rx.await.unwrap_or(None)
     }
 
-    /// Report that a peer has successfully shared a parameter
+    /// Report that a peer has successfully shared the hash of a blob ticket for a parameter
     pub fn report_success(&self, peer_id: NodeId) {
         let _ = self.peer_tx.send(PeerCommand::ReportSuccess { peer_id });
     }
 
-    /// Report that a peer has failed to share a parameter
-    pub fn report_error(&self, peer_id: NodeId) {
+    /// Report that a peer has failed to share the hash of the blob ticket for a model parameter
+    pub fn report_blob_ticket_request_error(&self, peer_id: NodeId) {
         if self
             .peer_tx
-            .send(PeerCommand::ReportError { peer_id })
+            .send(PeerCommand::ReportBlobTicketRequestError { peer_id })
             .is_err()
         {
             tracing::error!("Failed to report error for peer {peer_id}, PeerManager actor is dead");
         }
     }
 
-    /// Report that a peer has failed to share a parameter after retrying
-    pub fn report_retry_error(&self, peer_id: NodeId) {
+    /// Report that a peer has failed to in the middle of the download process of a blob ticket
+    pub fn report_blob_ticket_download_error(&self, peer_id: NodeId) {
         if self
             .peer_tx
-            .send(PeerCommand::ReportRetryError { peer_id })
+            .send(PeerCommand::ReportBlobTicketDownloadError { peer_id })
             .is_err()
         {
             tracing::error!(
@@ -111,33 +116,35 @@ impl PeerManagerHandle {
 }
 
 struct PeerManagerActor {
+    /// Peers that are available to request the model to
     available_peers: VecDeque<NodeId>,
-    errored_peers: HashMap<NodeId, (usize, usize)>, // (error_count, retry_count)
-    max_errors_per_peer: usize,
-    max_retries_per_peer: usize,
+    /// A map for the peer's blob ticket to their errors
+    /// A node could success sending the blob ticket but fail in the middle of the download so we differentiate between the two
+    /// Node -> (blob_ticket_request_errors, blob_ticket_downloads_errors)
+    errors_per_peers: HashMap<NodeId, (u8, u8)>,
+    /// Max errors we tolerate for a peer to share a parameter blob ticket
+    max_errors_per_peer: u8,
+    /// Max errors we tolerate for a peer to fail in the middle of the download of a parameter blob ticket
+    max_retries_per_peer: u8,
 }
 
 impl PeerManagerActor {
-    pub fn new(
-        initial_peers: Vec<NodeId>,
-        max_errors_per_peer: usize,
-        max_retries_per_peer: usize,
-    ) -> Self {
-        let available_peers = VecDeque::from(initial_peers);
-        let errored_peers: HashMap<NodeId, (usize, usize)> = HashMap::new();
+    pub fn new(max_errors_per_peer: u8, max_retries_per_peer: u8) -> Self {
         Self {
-            available_peers,
-            errored_peers,
+            available_peers: VecDeque::new(),
+            errors_per_peers: HashMap::new(),
             max_errors_per_peer,
             max_retries_per_peer,
         }
     }
 
-    fn handle_message(&mut self, message: PeerCommand) {
+    fn handle_message(&mut self, message: PeerCommand, cancellation_token: CancellationToken) {
         match message {
             PeerCommand::SetPeers { peers } => {
                 self.available_peers = VecDeque::from(peers);
-                self.errored_peers.clear();
+                let errors_per_peers_vec =
+                    self.available_peers.iter().map(|peer| (*peer, (0u8, 0u8)));
+                self.errors_per_peers = HashMap::from_iter(errors_per_peers_vec);
 
                 debug!(
                     "Updated peer list: {} peers available to ask for the model parameters",
@@ -154,38 +161,52 @@ impl PeerManagerActor {
                 };
                 let _ = reply.send(peer);
             }
-
             PeerCommand::ReportSuccess { peer_id } => {
                 self.available_peers.push_back(peer_id);
-                self.errored_peers.remove(&peer_id);
                 debug!("Peer {peer_id} correctly provided the blob ticket");
             }
-
-            PeerCommand::ReportError { peer_id } => {
-                let error_count = self.errored_peers.entry(peer_id).or_insert((0, 0));
+            PeerCommand::ReportBlobTicketRequestError { peer_id } => {
+                let error_count = self.errors_per_peers.entry(peer_id).or_insert((0, 0));
                 error_count.0 += 1;
 
-                if error_count.0 > self.max_errors_per_peer {
+                if error_count.0 >= self.max_errors_per_peer {
                     // Don't need to actually remove it because we already popped it, just don't add it back
                     warn!("Removing peer {peer_id} after {} errors", error_count.0);
 
-                    // Remove from errored to avoid keeping in there forever, we won't ask it again
-                    self.errored_peers.remove(&peer_id);
-                    if self.available_peers.is_empty() {
-                        warn!("No more peers available, keep checking if they start freeing up");
+                    if self.available_peers.is_empty()
+                        && self
+                            .errors_per_peers
+                            .iter()
+                            .all(|(_, (e, _))| *e == self.max_errors_per_peer)
+                    {
+                        error!(
+                            "No more peers available to ask for model blob tickets, terminate process"
+                        );
+                        cancellation_token.cancel();
                     }
                 } else {
                     self.available_peers.push_back(peer_id);
                 };
             }
-            PeerCommand::ReportRetryError { peer_id } => {
-                let error_count = self.errored_peers.entry(peer_id).or_insert((0, 0));
+            PeerCommand::ReportBlobTicketDownloadError { peer_id } => {
+                let error_count = self.errors_per_peers.entry(peer_id).or_insert((0, 0));
                 error_count.1 += 1;
 
-                if error_count.1 > self.max_retries_per_peer {
+                if error_count.1 >= self.max_retries_per_peer {
                     warn!("Removing peer {peer_id} after {} retries", error_count.1);
-                    self.errored_peers.remove(&peer_id);
                     self.available_peers.retain(|p| *p != peer_id);
+
+                    if self.available_peers.is_empty()
+                        && self
+                            .errors_per_peers
+                            .iter()
+                            .all(|(_, (e, _))| *e == self.max_retries_per_peer)
+                    {
+                        error!(
+                            "No more peers available to download blob tickets, terminate process"
+                        );
+                        cancellation_token.cancel();
+                    }
                 }
             }
         }
@@ -194,14 +215,14 @@ impl PeerManagerActor {
 
 async fn peer_manager_actor(
     mut rx: mpsc::UnboundedReceiver<PeerCommand>,
-    initial_peers: Vec<NodeId>,
-    max_errors_per_peer: usize,
-    max_retries_per_peer: usize,
+    max_errors_per_peer: u8,
+    max_retries_per_peer: u8,
+    cancellation_token: CancellationToken,
 ) {
-    let mut actor = PeerManagerActor::new(initial_peers, max_errors_per_peer, max_retries_per_peer);
+    let mut actor = PeerManagerActor::new(max_errors_per_peer, max_retries_per_peer);
 
     while let Some(message) = rx.recv().await {
-        actor.handle_message(message);
+        actor.handle_message(message, cancellation_token.clone());
     }
 }
 


### PR DESCRIPTION
Since we're hitting the `No provider nodes found` error fairly often, we’re adjusting how the retry logic works for downloading model parameters. Right now, the client gives up on a parameter after three consecutive failures, regardless of how many different peers were involved. It's a common situation to hit three failing peers in a row, so we need a more resilient approach.

The updated logic now distinguishes between two failure cases:

1. **Failure when requesting the blob ticket** – meaning the connection via the iroh protocol couldn’t even be established or there was an error generating the blob ticket for a parameter
2. **Failure mid-download** – where we successfully got the blob ticket, but the download fails afterward (often with the `No provider nodes found` error).

The new behavior is:

* If a peer fails **three times** to provide a blob ticket, we stop asking that peer altogether.
* If a peer provides the ticket but fails **mid-download** (e.g., times out or disconnects), we allow up to **five failures** before removing that peer from the list.

The model download process will only give up under two conditions:

* All known peers failed three times to give us a blob ticket.
* All known peers failed five times mid-download.

This change should make the retry logic more fault-tolerant and give us a better chance of eventually downloading the model, even under flaky network conditions or peer crashes.
