### PR TITLE
metrics: fix metrics server dying

### DIFF
--- a/architectures/centralized/client/src/app.rs
+++ b/architectures/centralized/client/src/app.rs
@@ -14,6 +14,7 @@ use psyche_network::{
 use psyche_tui::logging::LoggerWidget;
 use psyche_tui::{CustomWidget, TabbedWidget};
 use psyche_watcher::{Backend as WatcherBackend, CoordinatorTui, OpportunisticData};
+use std::sync::Arc;
 use std::{path::PathBuf, time::Duration};
 use tokio::sync::mpsc::Sender;
 use tokio::time::interval;
@@ -80,7 +81,7 @@ pub struct App {
     coordinator_state: Coordinator<ClientId>,
     server_conn: TcpClient<ClientId, ClientToServerMessage, ServerToClientMessage>,
 
-    metrics: ClientMetrics,
+    metrics: Arc<ClientMetrics>,
 }
 
 pub struct AppBuilder(AppParams);
@@ -127,7 +128,7 @@ impl AppBuilder {
     )> {
         let p = self.0;
 
-        let metrics = ClientMetrics::new(p.metrics_local_port);
+        let metrics = Arc::new(ClientMetrics::new(p.metrics_local_port));
         let server_conn =
             TcpClient::<ClientId, ClientToServerMessage, ServerToClientMessage>::connect(
                 &p.server_addr,

--- a/architectures/decentralized/solana-client/src/app.rs
+++ b/architectures/decentralized/solana-client/src/app.rs
@@ -50,7 +50,7 @@ pub struct App {
     update_tui_interval: Interval,
     tx_tui_state: Option<Sender<TabsData>>,
     authorizer: Option<Pubkey>,
-    metrics: ClientMetrics,
+    metrics: Arc<ClientMetrics>,
     allowlist: allowlist::AllowDynamic,
     p2p: NC,
     state_options: RunInitConfig<psyche_solana_coordinator::ClientId, NetworkIdentity>,
@@ -99,7 +99,7 @@ impl AppBuilder {
             *p.identity_secret_key.public().as_bytes(),
         );
 
-        let metrics = ClientMetrics::new(p.metrics_local_port);
+        let metrics = Arc::new(ClientMetrics::new(p.metrics_local_port));
 
         let allowlist = allowlist::AllowDynamic::new();
 

--- a/shared/client/src/client.rs
+++ b/shared/client/src/client.rs
@@ -60,7 +60,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
         allowlist: allowlist::AllowDynamic,
         mut p2p: NC,
         init_config: RunInitConfig<T, A>,
-        metrics: ClientMetrics,
+        metrics: Arc<ClientMetrics>,
     ) -> Self {
         let cancel = CancellationToken::new();
         let (tx_tui, rx_tui) = watch::channel::<TUIStates>(Default::default());

--- a/shared/metrics/src/lib.rs
+++ b/shared/metrics/src/lib.rs
@@ -20,7 +20,7 @@ pub use iroh::{IrohMetricsCollector, create_iroh_registry};
 pub use iroh_metrics::Registry as IrohMetricsRegistry;
 use tracing::{debug, info, warn};
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 /// metrics collector for Psyche clients
 pub struct ClientMetrics {
     // opentelemtery instruments

--- a/shared/network/examples/bandwidth_test.rs
+++ b/shared/network/examples/bandwidth_test.rs
@@ -19,6 +19,7 @@ use psyche_tui::{
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::{
     collections::HashMap,
     str::FromStr,
@@ -292,7 +293,7 @@ async fn main() -> Result<()> {
         secret_key,
         allowlist::AllowAll,
         4,
-        ClientMetrics::new(None),
+        Arc::new(ClientMetrics::new(None)),
     )
     .await?;
 

--- a/shared/network/src/lib.rs
+++ b/shared/network/src/lib.rs
@@ -122,7 +122,7 @@ where
     _broadcast_message: PhantomData<BroadcastMessage>,
     _download: PhantomData<Download>,
     update_stats_interval: Interval,
-    metrics: ClientMetrics,
+    metrics: Arc<ClientMetrics>,
     _iroh_metrics: IrohMetricsCollector,
 }
 
@@ -160,7 +160,7 @@ where
         secret_key: Option<SecretKey>,
         allowlist: A,
         max_concurrent_downloads: usize,
-        metrics: ClientMetrics,
+        metrics: Arc<ClientMetrics>,
     ) -> Result<Self> {
         let secret_key = match secret_key {
             None => SecretKey::generate(&mut rand::rngs::OsRng),

--- a/shared/network/src/test.rs
+++ b/shared/network/src/test.rs
@@ -202,7 +202,7 @@ async fn spawn_new_node(
         None,
         allowlist::AllowAll,
         20,
-        ClientMetrics::new(None),
+        Arc::new(ClientMetrics::new(None)),
     )
     .await?;
 


### PR DESCRIPTION
we cloned it a few places, but killed the shared task when any clone was dropped.

now it's unclonable and we pass it around as an Arc everywhere