### PR TITLE
local telemetry, new metrics, and cardinality reduction

### DIFF
--- a/architectures/centralized/server/src/main.rs
+++ b/architectures/centralized/server/src/main.rs
@@ -172,7 +172,7 @@ async fn main() -> Result<()> {
                     MetricsDestination::OpenTelemetry(OpenTelemetry {
                         endpoint,
                         authorization_header: run_args.oltp_auth_header.clone(),
-                        report_interval: Duration::from_secs(10),
+                        report_interval: Duration::from_secs(60),
                     })
                 }))
                 .with_trace_destination(run_args.oltp_tracing_url.clone().map(|endpoint| {

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ fmt:
 
 # spin up a local testnet
 local-testnet *args='':
-    cargo run -p psyche-centralized-local-testnet -- start {{ args }}
+    OLTP_METRICS_URL="http://localhost:4318/v1/metrics" OLTP_TRACING_URL="http://localhost:4318/v1/traces" OLTP_LOGS_URL="http://localhost:4318/v1/logs" cargo run -p psyche-centralized-local-testnet -- start {{ args }}
 
 # run integration tests
 integration-test test_name="":
@@ -55,6 +55,13 @@ start-training-localnet-client run_id="test" *args='':
 # Start client for training on localnet without data parallelism features and using light model.
 start-training-localnet-light-client run_id="test" *args='':
     RUN_ID={{ run_id }} BATCH_SIZE=1 DP=1 ./scripts/train-solana-test.sh {{ args }}
+
+OTLP_METRICS_URL := "http://localhost:4318/v1/metrics"
+OTLP_LOGS_URL := "http://localhost:4318/v1/logs"
+
+# The same command as above but with arguments set to export telemetry data
+start-training-localnet-light-client-telemetry run_id="test" *args='':
+    OTLP_METRICS_URL={{ OTLP_METRICS_URL }} OTLP_LOGS_URL={{ OTLP_LOGS_URL }} RUN_ID={{ run_id }} BATCH_SIZE=1 DP=1 ./scripts/train-solana-test.sh {{ args }}
 
 DEVNET_RPC := "https://api.devnet.solana.com"
 DEVNET_WS_RPC := "wss://api.devnet.solana.com"

--- a/scripts/train-solana-test.sh
+++ b/scripts/train-solana-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eo pipefail
 
 # use the agenix provided wallet if you have it
 DEFAULT_WALLET=${devnet__keypair__wallet_PATH:-"$HOME/.config/solana/id.json"}
@@ -19,14 +19,30 @@ solana airdrop 10 "$(solana-keygen pubkey ${WALLET_FILE})" --url "${RPC}" || tru
 
 export RUST_LOG="info,psyche=debug"
 
-cargo run --release --bin psyche-solana-client -- \
-    train \
-    --wallet-private-key-path ${WALLET_FILE} \
-    --rpc ${RPC} \
-    --ws-rpc ${WS_RPC} \
-    --run-id ${RUN_ID} \
-    --data-parallelism ${DP} \
-    --tensor-parallelism ${TP} \
-    --micro-batch-size ${BATCH_SIZE} \
-    --logs "console" \
-    "$@"
+if [[ "$OTLP_METRICS_URL" == "" ]]; then
+    cargo run --release --bin psyche-solana-client -- \
+        train \
+        --wallet-private-key-path ${WALLET_FILE} \
+        --rpc ${RPC} \
+        --ws-rpc ${WS_RPC} \
+        --run-id ${RUN_ID} \
+        --data-parallelism ${DP} \
+        --tensor-parallelism ${TP} \
+        --micro-batch-size ${BATCH_SIZE} \
+        --logs "console" \
+        "$@"
+else
+    cargo run --release --bin psyche-solana-client -- \
+        train \
+        --wallet-private-key-path ${WALLET_FILE} \
+        --rpc ${RPC} \
+        --ws-rpc ${WS_RPC} \
+        --run-id ${RUN_ID} \
+        --data-parallelism ${DP} \
+        --tensor-parallelism ${TP} \
+        --micro-batch-size ${BATCH_SIZE} \
+        --logs "console" \
+        --oltp-metrics-url "http://localhost:4318/v1/metrics" \
+        --oltp-logs-url "http://localhost:4318/v1/logs" \
+        "$@"
+fi

--- a/shared/client/src/cli.rs
+++ b/shared/client/src/cli.rs
@@ -87,7 +87,7 @@ pub struct TrainArgs {
 
     /// how often to report metrics thru opentelemetry
     #[clap(long, env,
-    default_value = "10.0",
+    default_value = "60.0",
     value_parser = parse_duration_from_seconds)]
     pub oltp_report_interval: Duration,
 

--- a/shared/client/src/client.rs
+++ b/shared/client/src/client.rs
@@ -244,7 +244,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                                 let apply_result = run.apply_message(client.id, broadcast)?;
                                                 match apply_result {
                                                     ApplyMessageOutcome::Ignored => {
-                                                        metrics.record_apply_message_ignored(broadcast_step, broadcast_kind);
+                                                        metrics.record_apply_message_ignored(broadcast_kind);
                                                     },
                                                     ApplyMessageOutcome::Applied => {
                                                         metrics.record_apply_message_success(broadcast_step, from, broadcast_kind);

--- a/shared/client/src/client.rs
+++ b/shared/client/src/client.rs
@@ -107,7 +107,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
 
                 let mut run = RunManager::<T, A>::new(RunInitConfigAndIO {
                     init_config,
-
+                    metrics: metrics.clone(),
                     tx_witness,
                     tx_health_check,
                     tx_checkpoint,

--- a/shared/client/src/client.rs
+++ b/shared/client/src/client.rs
@@ -102,7 +102,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                 let max_concurrent_parameter_requests =
                     init_config.max_concurrent_parameter_requests;
 
-                let mut current_downloaded_parameters = 0_u16;
+                let mut current_downloaded_parameters = 0_u64;
                 let mut total_parameters = None;
 
                 let mut run = RunManager::<T, A>::new(RunInitConfigAndIO {
@@ -178,6 +178,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                             ensure_gossip_connected(new_state, &mut p2p, &mut last_gossip_connection_time);
 
                             if old_state.map(|s| s.run_state) != Some(new_state.run_state) && new_state.run_state == RunState::RoundTrain {
+
                                 trace!("Updating p2p");
                                 let last_needed_step_blobs = new_state.progress.step.saturating_sub(2);
                                 p2p.remove_blobs_with_tag_less_than(last_needed_step_blobs);
@@ -279,6 +280,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                                                 info!("Download complete: parameter {}", parameter.name()?);
                                                 if let Some(total_parameters) = total_parameters {
                                                     info!("Downloaded parameters total: {}/{}", current_downloaded_parameters, total_parameters);
+                                                    metrics.update_model_sharing_total_params_downloaded(current_downloaded_parameters);
                                                 } else {
                                                     error!("Total parameters not set");
                                                 }
@@ -302,7 +304,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
 
                                         match dl.download_type {
                                             DownloadType::ModelSharing(request_type) => {
-                                                metrics.record_download_failed();
+                                                metrics.record_p2p_model_parameter_download_failed();
                                                 // We often get an error after some time in the iroh-blobs side so we use the base backoff to retry faster.
                                                 let backoff_duration = DOWNLOAD_RETRY_BACKOFF_BASE;
                                                 let retry_time = Some(std::time::Instant::now() + backoff_duration);
@@ -425,7 +427,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                             let transmittable_distro_result = TransmittableDownload::DistroResult(distro_result.clone());
                             let ticket = p2p.add_downloadable(transmittable_distro_result, step).await?;
                             let hash = ticket.hash();
-                            trace!(
+                            info!(
                                 client_id = %identity, step = step,
                                 "Broadcasting payload batch id {batch_id} hash 0x{}",
                                 hex::encode(hash),
@@ -530,6 +532,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static, B: Backend<T> + 'sta
                             sharable_model.update_config(config_string, tokenizer)?;
                         }
                         Some((param_names, tx_params_response)) = rx_parameters_req.recv() => {
+                            metrics.initialize_model_parameters_gauge(param_names.len().try_into().unwrap());
                             total_parameters = Some(param_names.len());
                             sharable_model.initialize_parameters(&param_names, tx_params_response);
 

--- a/shared/client/src/state/init.rs
+++ b/shared/client/src/state/init.rs
@@ -9,6 +9,7 @@ use psyche_data_provider::{
     download_model_repo_async,
     http::{FileURLs, HttpDataProvider},
 };
+use psyche_metrics::ClientMetrics;
 use psyche_modeling::{
     AutoConfig, AutoTokenizerError, CausalLM, CommunicatorId, DataParallel, DeepseekForCausalLM,
     DummyModel, LlamaConfig, LlamaForCausalLM, LocalTrainer, ModelConfig, ModelLoadError,
@@ -151,6 +152,8 @@ pub struct RunInitConfigAndIO<T: NodeIdentity, A: AuthenticatableIdentity> {
     pub tx_request_download: UnboundedSender<(BlobTicket, u32)>,
     pub tx_request_model_config: UnboundedSender<OneShotModelConfigSender>,
     pub tx_broadcast_finished: UnboundedSender<FinishedBroadcast>,
+
+    pub metrics: Arc<ClientMetrics>,
 }
 
 impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> RunInitConfigAndIO<T, A> {
@@ -171,6 +174,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> RunInitConfigAndIO<T
             tx_request_download,
             tx_request_model_config,
             tx_broadcast_finished,
+            metrics,
         } = self;
 
         let model::Model::LLM(llm) = state.model;
@@ -700,8 +704,13 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> RunInitConfigAndIO<T
 
         let wandb_run = wandb_run.map_err(InitRunError::WandbThreadCrashed)??;
 
-        let stats_logger =
-            StatsLogger::new(tokenizer, eval_runner.clone(), llm.lr_schedule, wandb_run);
+        let stats_logger = StatsLogger::new(
+            tokenizer,
+            eval_runner.clone(),
+            llm.lr_schedule,
+            wandb_run,
+            metrics,
+        );
 
         let warmup = WarmupStepMetadata {
             eval_runner: eval_runner.clone(),

--- a/shared/client/src/state/stats.rs
+++ b/shared/client/src/state/stats.rs
@@ -1,5 +1,6 @@
 use psyche_coordinator::{Coordinator, WitnessEvalResult, WitnessMetadata, model};
 use psyche_core::{BoundedQueue, FixedVec, LearningRateSchedule, NodeIdentity};
+use psyche_metrics::ClientMetrics;
 use psyche_modeling::Trainer;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokenizers::Tokenizer;
@@ -13,6 +14,7 @@ use super::evals::EvalRunner;
 pub struct StatsLogger {
     tokenizer: Arc<Tokenizer>,
     wandb_run: Option<Arc<wandb::Run>>,
+    pub metrics: Arc<ClientMetrics>,
     eval_runner: EvalRunner,
 
     step_durations: BoundedQueue<Duration, 16>,
@@ -32,6 +34,7 @@ impl StatsLogger {
         eval_runner: EvalRunner,
         lr_schedule: LearningRateSchedule,
         wandb_run: Option<wandb::Run>,
+        metrics: Arc<ClientMetrics>,
     ) -> Self {
         Self {
             tokenizer,
@@ -44,6 +47,7 @@ impl StatsLogger {
             eval_history: HashMap::new(),
             last_optim_stats: HashMap::new(),
             node_info: HashMap::new(),
+            metrics,
         }
     }
 

--- a/shared/client/src/state/stats.rs
+++ b/shared/client/src/state/stats.rs
@@ -56,49 +56,85 @@ impl StatsLogger {
 
         round_log.insert("_step", state.progress.step);
 
+        // Training metrics
         if let Some(loss) = self.losses().last() {
-            round_log.insert("train/loss", *loss);
-            round_log.insert("train/perplexity", perplexity(*loss));
-            round_log.insert("train/confidence", self.confidence(*loss));
+            let loss_val = *loss;
+            let perplexity_val = perplexity(loss_val);
+            let confidence_val = self.confidence(loss_val);
+
+            round_log.insert("train/loss", loss_val);
+            round_log.insert("train/perplexity", perplexity_val);
+            round_log.insert("train/confidence", confidence_val);
+
+            // Log to metrics
+            self.metrics.record_training_loss(loss_val as f64);
+            self.metrics
+                .record_training_perplexity(perplexity_val as f64);
+            self.metrics
+                .record_training_confidence(confidence_val as f64);
         }
-        round_log.insert(
-            "train/lr",
-            Trainer::get_lr(
-                &self.lr_schedule,
-                state.progress.step,
-                state.get_cold_start_warmup_bounds(),
-            ),
+
+        let lr = Trainer::get_lr(
+            &self.lr_schedule,
+            state.progress.step,
+            state.get_cold_start_warmup_bounds(),
         );
+        round_log.insert("train/lr", lr);
+        self.metrics.record_learning_rate(lr);
 
-        round_log.insert("train/total_tokens", total_tokens(state));
-        round_log.insert("train/tokens_per_sec", self.global_tokens_per_second(state));
-        round_log.insert("train/global_token_batch_size", token_batch_size(state));
-        round_log.insert("train/efficency", self.efficency());
+        let total_tokens_val = total_tokens(state);
+        let tokens_per_sec_val = self.global_tokens_per_second(state);
+        let token_batch_size_val = token_batch_size(state);
+        let efficiency_val = self.efficency();
 
-        round_log.insert("coordinator/num_clients", state.epoch_state.clients.len());
-        round_log.insert("coordinator/epoch", state.progress.epoch);
-        round_log.insert(
-            "coordinator/round",
-            state.current_round().map(|x| x.height).unwrap_or_default(),
-        );
+        round_log.insert("train/total_tokens", total_tokens_val);
+        round_log.insert("train/tokens_per_sec", tokens_per_sec_val);
+        round_log.insert("train/global_token_batch_size", token_batch_size_val);
+        round_log.insert("train/efficency", efficiency_val);
 
+        self.metrics.record_total_tokens(total_tokens_val);
+        self.metrics
+            .record_tokens_per_second(tokens_per_sec_val as f64);
+        self.metrics
+            .record_token_batch_size(token_batch_size_val as u64);
+        self.metrics
+            .record_training_efficiency(efficiency_val as f64);
+        if let Some(last_train_time) = self.training_round_durations.iter().last() {
+            self.metrics
+                .record_last_train_time(last_train_time.as_secs_f64());
+        }
+        // Coordinator metrics
+        let num_clients = state.epoch_state.clients.len();
+        let epoch = state.progress.epoch;
+        let round_height = state.current_round().map(|x| x.height).unwrap_or_default();
+
+        round_log.insert("coordinator/num_clients", num_clients);
+        round_log.insert("coordinator/epoch", epoch);
+        round_log.insert("coordinator/round", round_height);
+
+        // Eval metrics
         for (key, val) in self.current_eval_results() {
-            round_log.insert(
-                format!(
-                    "eval/{}",
-                    key.to_lowercase()
-                        .chars()
-                        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-                        .collect::<String>()
-                ),
-                val,
+            let formatted_key = format!(
+                "eval/{}",
+                key.to_lowercase()
+                    .chars()
+                    .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+                    .collect::<String>()
             );
+            round_log.insert(formatted_key.clone(), val);
+
+            self.metrics.record_eval_metric(&key, val);
         }
 
+        // Optimizer metrics
         for (name, value) in &self.last_optim_stats {
-            round_log.insert(format!("optim/{name}"), *value);
+            let optim_key = format!("optim/{name}");
+            round_log.insert(optim_key, *value);
+
+            self.metrics.record_optimizer_stat(name, *value);
         }
 
+        // P2P nodes (only for wandb, not metrics as requested)
         let p2p_nodes: HashMap<String, DataValue> = self
             .node_info
             .iter()
@@ -116,6 +152,7 @@ impl StatsLogger {
 
         round_log.insert("p2p/nodes", p2p_nodes);
 
+        // Log to wandb
         if let Some(run) = self.wandb_run.clone() {
             tokio::spawn(async move {
                 run.log(round_log).await;

--- a/shared/client/src/state/steps.rs
+++ b/shared/client/src/state/steps.rs
@@ -89,6 +89,9 @@ pub enum StepError {
 pub enum ApplyMessageError {
     #[error("Failed to put blob up for download")]
     StartDownloadBlob,
+
+    #[error("Stats logger mutex is poisoned")]
+    StatsLoggerMutex,
 }
 
 #[derive(Error, Debug)]
@@ -338,10 +341,10 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> StepStateMachine<T, 
         broadcast: Broadcast,
     ) -> Result<ApplyMessageOutcome, ApplyMessageError> {
         let result_step = broadcast.step;
-        let round_state = if self.current_round.step == broadcast.step {
-            &mut self.current_round
+        let (round_state, current_round) = if self.current_round.step == broadcast.step {
+            (&mut self.current_round, true)
         } else if self.previous_round.step == broadcast.step {
-            &mut self.previous_round
+            (&mut self.previous_round, false)
         } else {
             trace!(
                 "Unknown round for gossiped, says it's for step {} but our current round is step {} and previous round is step {}",
@@ -451,11 +454,21 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> StepStateMachine<T, 
                 let download_state =
                     PayloadState::Downloading((from_client_id, batch_id, ticket.clone()));
 
-                round_state
-                    .downloads
+                let mut downloads = round_state.downloads.lock().unwrap();
+
+                downloads.insert(hash, download_state);
+
+                self.stats_logger
                     .lock()
-                    .unwrap()
-                    .insert(hash, download_state);
+                    .map_err(|_| ApplyMessageError::StatsLoggerMutex)?
+                    .metrics
+                    .record_result_announcements_received(
+                        downloads.len() as u64,
+                        broadcast.step,
+                        current_round,
+                        hex::encode(broadcast.commitment.data_hash),
+                        from_client_id,
+                    );
 
                 // start downloading the payload unless this is a self-message
                 // (assuming the caller will put our payload in the proper place)
@@ -477,6 +490,18 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> StepStateMachine<T, 
                 round_state
                     .clients_finished
                     .insert(from_client_id, finished.clone());
+
+                self.stats_logger
+                    .lock()
+                    .map_err(|_| ApplyMessageError::StatsLoggerMutex)?
+                    .metrics
+                    .record_finishes_received(
+                        round_state.clients_finished.len() as u64,
+                        broadcast.step,
+                        current_round,
+                        hex::encode(broadcast.commitment.data_hash),
+                        from_client_id,
+                    );
 
                 if finished.warmup {
                     info!(
@@ -506,22 +531,23 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> StepStateMachine<T, 
         distro_result: TransmittableDistroResult,
         self_result: Option<Vec<DistroResult>>,
     ) {
-        let round_state = if self.current_round.distro_result_blob_downloaded(&hash) {
-            trace!(
-                "Got download {hash} for current round {}",
-                self.current_round.height
-            );
-            &mut self.current_round
-        } else if self.previous_round.distro_result_blob_downloaded(&hash) {
-            trace!(
-                "Got download {hash} for previous round {}",
-                self.previous_round.height
-            );
-            &mut self.previous_round
-        } else {
-            warn!("Unknown download {}", hash);
-            return;
-        };
+        let (round_state, current_round) =
+            if self.current_round.distro_result_blob_downloaded(&hash) {
+                trace!(
+                    "Got download {hash} for current round {}",
+                    self.current_round.height
+                );
+                (&mut self.current_round, true)
+            } else if self.previous_round.distro_result_blob_downloaded(&hash) {
+                trace!(
+                    "Got download {hash} for previous round {}",
+                    self.previous_round.height
+                );
+                (&mut self.previous_round, false)
+            } else {
+                warn!("Unknown download {}", hash);
+                return;
+            };
 
         if let Some(self_result) = self_result {
             trace!(
@@ -569,6 +595,7 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> StepStateMachine<T, 
         let batch_ids_not_yet_trained_on = round_state.batch_ids_not_yet_trained_on.clone();
         let blooms = round_state.blooms.clone();
         let downloads = round_state.downloads.clone();
+        let stats_logger = self.stats_logger.clone();
         tokio::spawn(async move {
             // verify that the result matches the commitment
             let (distro_hash, distro_result) =
@@ -645,10 +672,15 @@ impl<T: NodeIdentity, A: AuthenticatableIdentity + 'static> StepStateMachine<T, 
                 Ok(maybe_results)
             });
 
-            downloads
+            let mut downloads = downloads.lock().unwrap();
+
+            downloads.insert(hash, PayloadState::Deserializing(deserializing));
+
+            stats_logger
                 .lock()
-                .unwrap()
-                .insert(hash, PayloadState::Deserializing(deserializing));
+                .expect("stats logger mutex poisoned")
+                .metrics
+                .record_result_downloaded(downloads.len() as u64, current_round, hash, batch_id);
         });
     }
 

--- a/shared/metrics/src/lib.rs
+++ b/shared/metrics/src/lib.rs
@@ -225,36 +225,21 @@ impl ClientMetrics {
 
     pub fn record_apply_message_success(&self, step: u32, from_peer: impl Display, kind: &str) {
         debug!(name: "apply_message_success", step=%step, kind=%kind, from=%from_peer);
-        self.apply_message_success_counter.add(
-            1,
-            &[
-                KeyValue::new("step", step as i64),
-                KeyValue::new("type", kind.to_string()),
-            ],
-        );
+        self.apply_message_success_counter
+            .add(1, &[KeyValue::new("type", kind.to_string())]);
         self.tcp_metrics.lock().unwrap().apply_message_success += 1;
     }
 
     pub fn record_apply_message_failure(&self, step: u32, from_peer: impl Display, kind: &str) {
         debug!(name: "apply_message_failure", step=%step, kind=%kind, from=%from_peer);
-        self.apply_message_failure_counter.add(
-            1,
-            &[
-                KeyValue::new("step", step as i64),
-                KeyValue::new("type", kind.to_string()),
-            ],
-        );
+        self.apply_message_failure_counter
+            .add(1, &[KeyValue::new("type", kind.to_string())]);
         self.tcp_metrics.lock().unwrap().apply_message_failure += 1;
     }
 
-    pub fn record_apply_message_ignored(&self, step: u32, kind: impl Display) {
-        self.apply_message_ignored_counter.add(
-            1,
-            &[
-                KeyValue::new("step", step as i64),
-                KeyValue::new("type", kind.to_string()),
-            ],
-        );
+    pub fn record_apply_message_ignored(&self, kind: impl Display) {
+        self.apply_message_ignored_counter
+            .add(1, &[KeyValue::new("type", kind.to_string())]);
         self.tcp_metrics.lock().unwrap().apply_message_ignored += 1;
     }
 
@@ -276,11 +261,9 @@ impl ClientMetrics {
         self.tcp_metrics.lock().unwrap().downloads_retry += 1;
     }
 
-    pub fn update_download_progress(&self, hash: impl Display, newly_downloaded_bytes: u64) {
-        self.downloads_bytes_counter.add(
-            newly_downloaded_bytes,
-            &[KeyValue::new("hash", hash.to_string())],
-        );
+    pub fn update_download_progress(&self, newly_downloaded_bytes: u64) {
+        self.downloads_bytes_counter
+            .add(newly_downloaded_bytes, &[]);
         self.tcp_metrics.lock().unwrap().downloads_bytes += newly_downloaded_bytes;
     }
 

--- a/shared/network/src/lib.rs
+++ b/shared/network/src/lib.rs
@@ -526,7 +526,7 @@ where
                         Ok(Some(NetworkEvent::DownloadComplete(result)))
                     }
                     Some(DownloadManagerEvent::Update(update)) => {
-                        self.metrics.update_download_progress(update.blob_ticket.hash(), update.downloaded_size_delta);
+                        self.metrics.update_download_progress(update.downloaded_size_delta);
                         Ok(self.on_download_update(update))
                     },
                     Some(DownloadManagerEvent::Failed(result)) => {

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,0 +1,21 @@
+# Local telemetry setup
+
+To spawn a local telemetry stack with OpenTelemetry for telemetry collection, Prometheus for metrics, Loki for logs and
+Grafana for visualization, run
+
+```bash
+docker compose -f telemetry/docker-compose.yml up
+```
+
+from the root of the repository.
+
+Once the telemetry stack is up, start your local training setup as usual, but remember to add the OTLP arguments when
+running the Psyche client:
+
+```
+OTLP_METRICS_URL = "http://localhost:4318/v1/metrics" # OpenTelemetry collector metrics endpoint
+OTLP_LOGS_URL = "http://localhost:4318/v1/logs"       # OpenTelemetry collector logs endpoint
+```
+
+For convenience, you can run `just start-training-localnet-light-client-telemetry` to start the Psyche client with
+the arguments already set for telemetry collection

--- a/telemetry/docker-compose.yml
+++ b/telemetry/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3.8'
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.128.0
+    command: ['--config=/etc/otel-collector-config.yaml']
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - '4317:4317' # OTLP gRPC receiver
+      - '4318:4318' # OTLP HTTP receiver
+      - '8889:8889' # Prometheus metrics endpoint
+      - '55679:55679'
+    depends_on:
+      - loki
+      - prometheus
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+
+  loki:
+    image: grafana/loki:latest
+    command: -config.file=/etc/loki/loki-config.yaml
+    volumes:
+      - ./loki-config.yaml:/etc/loki/loki-config.yaml
+    ports:
+      - '3100:3100'
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      GF_PATHS_PROVISIONING: /etc/grafana/provisioning
+      # For quick local testing, this should not be used in production
+      GF_AUTH_ANONYMOUS_ENABLED: 'true'
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning/
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    ports:
+      - '3000:3000'
+    depends_on:
+      - loki
+      - prometheus

--- a/telemetry/grafana/dashboards/clients_dashboard.json
+++ b/telemetry/grafana/dashboards/clients_dashboard.json
@@ -1,0 +1,773 @@
+{
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": {
+					"type": "grafana",
+					"uid": "-- Grafana --"
+				},
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 0,
+	"id": 1,
+	"links": [],
+	"panels": [
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 0
+			},
+			"id": 7,
+			"panels": [],
+			"title": "State",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "PBFA97CFB590B2093"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green"
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 1
+			},
+			"id": 5,
+			"options": {
+				"minVizHeight": 75,
+				"minVizWidth": 75,
+				"orientation": "auto",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"showThresholdLabels": false,
+				"showThresholdMarkers": false,
+				"sizing": "auto"
+			},
+			"pluginVersion": "12.0.2",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "PBFA97CFB590B2093"
+					},
+					"disableTextWrap": false,
+					"editorMode": "builder",
+					"expr": "psyche_round_step{exported_instance=\"$clients\"}",
+					"fullMetaSearch": false,
+					"includeNullMetadata": true,
+					"legendFormat": "__auto",
+					"range": true,
+					"refId": "A",
+					"useBackend": false
+				}
+			],
+			"title": "Round step",
+			"type": "gauge"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "PBFA97CFB590B2093"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"barWidthFactor": 0.6,
+						"drawStyle": "line",
+						"fillOpacity": 0,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"insertNulls": false,
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "auto",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green"
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 1
+			},
+			"id": 4,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": true
+				},
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "single",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "12.0.2",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "PBFA97CFB590B2093"
+					},
+					"disableTextWrap": false,
+					"editorMode": "builder",
+					"expr": "psyche_gossip_neighbors{exported_instance=\"$clients\"}",
+					"fullMetaSearch": false,
+					"includeNullMetadata": true,
+					"legendFormat": "__auto",
+					"range": true,
+					"refId": "A",
+					"useBackend": false
+				}
+			],
+			"title": "Gossip neighbors",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "P8E80F9AEF21F6940"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"barWidthFactor": 0.1,
+						"drawStyle": "bars",
+						"fillOpacity": 0,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"insertNulls": false,
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 6,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "auto",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green"
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 9
+			},
+			"id": 9,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": true
+				},
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "single",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "12.0.2",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "P8E80F9AEF21F6940"
+					},
+					"direction": "backward",
+					"editorMode": "builder",
+					"expr": "{instance=\"$clients\"} |= `Got training output, DisTrO results generated`",
+					"hide": false,
+					"queryType": "range",
+					"refId": "A"
+				}
+			],
+			"title": "Training completed in step",
+			"transformations": [
+				{
+					"id": "calculateField",
+					"options": {
+						"binary": {
+							"left": {
+								"matcher": {
+									"id": "byName",
+									"options": "Line"
+								}
+							},
+							"right": {
+								"fixed": "1"
+							}
+						},
+						"mode": "reduceRow",
+						"reduce": {
+							"reducer": "sum"
+						}
+					}
+				},
+				{
+					"id": "calculateField",
+					"options": {
+						"binary": {
+							"left": {
+								"matcher": {
+									"id": "byName",
+									"options": "Total"
+								}
+							},
+							"right": {
+								"fixed": "1"
+							}
+						},
+						"mode": "binary",
+						"reduce": {
+							"reducer": "sum"
+						},
+						"replaceFields": true
+					}
+				}
+			],
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "PBFA97CFB590B2093"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"fillOpacity": 50,
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"pointShape": "circle",
+						"pointSize": {
+							"fixed": 5
+						},
+						"pointStrokeWidth": 3,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"show": "points+lines"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green"
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 9
+			},
+			"id": 10,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"mapping": "auto",
+				"series": [{}],
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "single",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "12.0.2",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "PBFA97CFB590B2093"
+					},
+					"disableTextWrap": false,
+					"editorMode": "builder",
+					"expr": "psyche_round_step{exported_instance=\"$clients\"}",
+					"fullMetaSearch": false,
+					"includeNullMetadata": true,
+					"legendFormat": "round step",
+					"range": true,
+					"refId": "A",
+					"useBackend": false
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "PBFA97CFB590B2093"
+					},
+					"disableTextWrap": false,
+					"editorMode": "builder",
+					"expr": "psyche_last_train_time_seconds{exported_instance=\"$clients\"}",
+					"fullMetaSearch": false,
+					"hide": false,
+					"includeNullMetadata": true,
+					"instant": false,
+					"legendFormat": "time",
+					"range": true,
+					"refId": "B",
+					"useBackend": false
+				}
+			],
+			"title": "Training round duration",
+			"transformations": [
+				{
+					"id": "concatenate",
+					"options": {
+						"frameNameLabel": "Hola",
+						"frameNameMode": "field"
+					}
+				}
+			],
+			"type": "xychart"
+		},
+		{
+			"collapsed": true,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 17
+			},
+			"id": 8,
+			"panels": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "PBFA97CFB590B2093"
+					},
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisBorderShow": false,
+								"axisCenteredZero": false,
+								"axisColorMode": "text",
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"barWidthFactor": 0.6,
+								"drawStyle": "line",
+								"fillOpacity": 0,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"insertNulls": false,
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "auto",
+								"spanNulls": false,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"max": 120,
+							"min": 0,
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green"
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							}
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 52
+					},
+					"id": 2,
+					"options": {
+						"legend": {
+							"calcs": ["max"],
+							"displayMode": "list",
+							"placement": "bottom",
+							"showLegend": false
+						},
+						"tooltip": {
+							"hideZeros": false,
+							"mode": "single",
+							"sort": "none"
+						}
+					},
+					"pluginVersion": "12.0.2",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "PBFA97CFB590B2093"
+							},
+							"disableTextWrap": false,
+							"editorMode": "builder",
+							"expr": "psyche_p2p_model_params_downloaded{exported_instance=\"$clients\"}",
+							"fullMetaSearch": false,
+							"includeNullMetadata": true,
+							"legendFormat": "{{label_name}}",
+							"range": true,
+							"refId": "A",
+							"useBackend": false
+						}
+					],
+					"title": "P2P downloaded parameters (%)",
+					"type": "timeseries"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "PBFA97CFB590B2093"
+					},
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisBorderShow": false,
+								"axisCenteredZero": false,
+								"axisColorMode": "text",
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"barWidthFactor": 0.6,
+								"drawStyle": "line",
+								"fillOpacity": 0,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"insertNulls": false,
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "auto",
+								"spanNulls": false,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green"
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							}
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 52
+					},
+					"id": 3,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom",
+							"showLegend": true
+						},
+						"tooltip": {
+							"hideZeros": false,
+							"mode": "single",
+							"sort": "none"
+						}
+					},
+					"pluginVersion": "12.0.2",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "PBFA97CFB590B2093"
+							},
+							"disableTextWrap": false,
+							"editorMode": "builder",
+							"expr": "psyche_p2p_params_download_failed_counter_total{exported_instance=\"$clients\"}",
+							"fullMetaSearch": false,
+							"includeNullMetadata": true,
+							"legendFormat": "__auto",
+							"range": true,
+							"refId": "A",
+							"useBackend": false
+						}
+					],
+					"title": "P2P failed downloads",
+					"type": "timeseries"
+				}
+			],
+			"title": "P2P model sharing",
+			"type": "row"
+		},
+		{
+			"collapsed": true,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 18
+			},
+			"id": 6,
+			"panels": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "P8E80F9AEF21F6940"
+					},
+					"fieldConfig": {
+						"defaults": {},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 10,
+						"w": 24,
+						"x": 0,
+						"y": 53
+					},
+					"id": 1,
+					"options": {
+						"dedupStrategy": "none",
+						"enableInfiniteScrolling": false,
+						"enableLogDetails": true,
+						"prettifyLogMessage": false,
+						"showCommonLabels": false,
+						"showLabels": false,
+						"showTime": true,
+						"sortOrder": "Descending",
+						"wrapLogMessage": false
+					},
+					"pluginVersion": "12.0.2",
+					"repeat": "clients",
+					"repeatDirection": "h",
+					"targets": [
+						{
+							"datasource": {
+								"type": "loki",
+								"uid": "P8E80F9AEF21F6940"
+							},
+							"direction": "backward",
+							"editorMode": "builder",
+							"expr": "{instance=\"$clients\"}",
+							"queryType": "range",
+							"refId": "A"
+						}
+					],
+					"title": "Logs",
+					"type": "logs"
+				}
+			],
+			"title": "Logs",
+			"type": "row"
+		}
+	],
+	"preload": false,
+	"refresh": "30s",
+	"schemaVersion": 41,
+	"tags": [],
+	"templating": {
+		"list": [
+			{
+				"current": {
+					"text": "dd69b8c8755d8e900991b724cbd334d95665e2455cb3f9d3ba29fe6e1f59f00f",
+					"value": "dd69b8c8755d8e900991b724cbd334d95665e2455cb3f9d3ba29fe6e1f59f00f"
+				},
+				"definition": "",
+				"name": "clients",
+				"options": [],
+				"query": {
+					"label": "instance",
+					"refId": "LokiVariableQueryEditor-VariableQuery",
+					"stream": "",
+					"type": 1
+				},
+				"refresh": 1,
+				"regex": "",
+				"type": "query"
+			}
+		]
+	},
+	"time": {
+		"from": "now-15m",
+		"to": "now"
+	},
+	"timepicker": {},
+	"timezone": "browser",
+	"title": "Clients",
+	"uid": "516c64b6-0d50-4a36-a3fe-c562a5a91771",
+	"version": 5
+}

--- a/telemetry/grafana/provisioning/dashboards/dashboard.yaml
+++ b/telemetry/grafana/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: '' # Empty for root folder, or specify a folder name
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true # Allow editing dashboards in UI
+    options:
+      path: /var/lib/grafana/dashboards # Path inside container

--- a/telemetry/grafana/provisioning/datasources/datasources.yaml
+++ b/telemetry/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,17 @@
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100 # Connects to the Loki service defined in docker-compose.yml
+    isDefault: true
+    version: 1
+    editable: true
+
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090 # Connects to the Prometheus service defined in docker-compose.yml
+    isDefault: false
+    version: 1
+    editable: true

--- a/telemetry/loki-config.yaml
+++ b/telemetry/loki-config.yaml
@@ -1,0 +1,25 @@
+auth_enabled: false # For local dev, disable in production
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9095
+
+common:
+  path_prefix: /tmp/loki
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-27
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true

--- a/telemetry/otel-collector-config.yaml
+++ b/telemetry/otel-collector-config.yaml
@@ -1,0 +1,42 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 512
+
+exporters:
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
+
+  prometheus:
+    endpoint: '0.0.0.0:8889'
+    const_labels:
+      service: 'otel-collector'
+
+  # Useful for debugging to see logs in the collector's stdout
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [loki, debug]
+
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus, debug]

--- a/telemetry/prometheus.yml
+++ b/telemetry/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: ['otel-collector:8889']
+    scrape_interval: 10s
+    metrics_path: /metrics
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
The idea of this PR is to add a custom dashboard that can be useful as a starting point to monitor the state of each client more easily.

In the dashboard, there is a dropdown to select each of the connected clients:

<img width="715" height="207" alt="Screenshot 2025-07-25 at 3 29 31 PM" src="https://github.com/user-attachments/assets/ca13a485-25e9-4f5d-b0e8-7be437aa6b8e"/>

Once a client is selected, you can see three visualization rows.
The first one, shows a couple of general metrics of the client state, like the current step, the number of gossip neighbors and a plot visualizing when the client finished training in a step:

<img width="1493" height="649" alt="Screenshot 2025-07-25 at 3 34 33 PM" src="https://github.com/user-attachments/assets/8d61579e-b0a5-44dd-a63e-6953ca35d026" />

The second one shows some visualizations for the p2p model sharing state of the client, mostly relevant when the client joins a run and requests the parameters to other peers:

<img width="1497" height="349" alt="Screenshot 2025-07-25 at 3 42 58 PM" src="https://github.com/user-attachments/assets/e8f4d5e6-3f1a-43ae-ad2f-b3234f9dd332" />

The third one shows the logs for that client:

<img width="1492" height="430" alt="Screenshot 2025-07-25 at 3 46 42 PM" src="https://github.com/user-attachments/assets/00626804-2a50-4940-a0e1-d1342ec34558" />

---

A readme has been also added for spawning the telemetry stack locally in `/telemetry/README.md`. This is only meant as a starting point, suggestions for new metrics or to make the ones present better are appreciated!
