### PR TITLE
ci: don't build the psyche solana test docker package

### DIFF
--- a/garnix.yaml
+++ b/garnix.yaml
@@ -41,6 +41,7 @@ builds:
   # on main, might as well build everything, though
   - exclude:
       - '*.aarch64-darwin.*'
+      - 'packages.*.docker-psyche-solana-test-validator'
     include:
       - 'packages.x86_64-linux.*'
       - devShells.aarch64-darwin.default


### PR DESCRIPTION
it requires impure, so can't possibly build.