### PR TITLE
Add macOS/aarch64 development support

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -75,6 +75,10 @@
                 # the docs for nix-gl-host say this is a dangerous footgun but.. yolo
                 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(${pkgs.nix-gl-host}/bin/nixglhost -p)
               ''
+              + lib.optionalString pkgs.stdenv.isDarwin ''
+                # macOS: Ensure PyTorch can use Metal Performance Shaders
+                export PYTORCH_ENABLE_MPS_FALLBACK=1
+              ''
               + ''
                 echo "Welcome to the Psyche development shell.";
               '';

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -78,6 +78,9 @@
               + lib.optionalString pkgs.stdenv.isDarwin ''
                 # macOS: Ensure PyTorch can use Metal Performance Shaders
                 export PYTORCH_ENABLE_MPS_FALLBACK=1
+
+                # Set up PyTorch library path for test execution
+                export DYLD_LIBRARY_PATH="${pkgs.python312Packages.torch-bin}/lib/python3.12/site-packages/torch/lib:$DYLD_LIBRARY_PATH"
               ''
               + ''
                 echo "Welcome to the Psyche development shell.";

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -6,6 +6,8 @@
 
 let
   cudaSupported = builtins.elem system [ "x86_64-linux" ];
+  metalSupported = builtins.elem system [ "aarch64-darwin" ];
+  gpuSupported = cudaSupported || metalSupported;
 in
 (
   lib.optionalAttrs (system != null) { inherit system; }
@@ -35,6 +37,9 @@ in
       // lib.optionalAttrs cudaSupported {
         cudaSupport = true;
         cudaVersion = "12.8";
+      }
+      // lib.optionalAttrs metalSupported {
+        metalSupport = true;
       };
   }
 )

--- a/psyche-book/src/development/setup.md
+++ b/psyche-book/src/development/setup.md
@@ -7,7 +7,7 @@ This is the preferred way of working on Psyche, as it guarantees a consistent de
 
 If you can't / don't want to use Nix, it's also possible to manually install all the required deps for Psyche.
 
-### Any Linux, via Nix
+### Linux & macOS via Nix
 
 #### Installing Nix
 
@@ -36,6 +36,11 @@ After running `direnv allow` in the Psyche directory once, your terminal will au
 #### Setup Without `direnv`
 
 Each time you open a new shell in the Psyche directory, run `nix develop` to enter a development shell.
+
+#### Platform Differences
+
+- **Linux**: Uses CUDA for NVIDIA GPUs. Full distributed training support with NCCL.
+- **macOS**: Uses Metal Performance Shaders for Apple Silicon GPUs. Single-GPU only (parallelism features disabled).
 
 ### Ubuntu
 
@@ -127,11 +132,6 @@ LIBTORCH = <path_to_libtorch>
 OPENSSL_LIB_DIR = <path_to_openssl>/lib/VC/x64/MT
 OPENSSL_INCLUDE_DIR = <path_to_openssl>/include
 ```
-
-### MacOS / aarch64
-
-These platforms aren't supported right now :(
-PRs welcome!
 
 ### Docker
 

--- a/psyche-book/src/enduser/client-faq.md
+++ b/psyche-book/src/enduser/client-faq.md
@@ -1,9 +1,11 @@
 # Client FAQ
 
 - Which operating systems are supported?
-  - We support officially support modern Linux versions, with Mac support planned for the future once the Metal backend is implemented.
+  - We officially support modern Linux versions. macOS is supported for development purposes only (not for production training).
 - What are the hardware requirements to run a client?
-  - You need a CUDA-compatible GPU. As for the exact specs this will depend on the size of the model being trained. Support for AMD ROCm is planned for the future.
+  - Linux: You need a CUDA-compatible GPU. As for the exact specs this will depend on the size of the model being trained.
+  - macOS (development only): Apple Silicon Macs can use Metal Performance Shaders for GPU acceleration.
+  - Support for AMD ROCm is planned for the future.
 - Can I join a run at any moment?
   - Yes! You will remain as a pending client and start training in the next epoch.
 - Can I leave a run at any moment? How do I leave a run?

--- a/python/build.rs
+++ b/python/build.rs
@@ -13,6 +13,26 @@ fn main() {
                 println!("cargo:rustc-link-arg=-Wl,--copy-dt-needed-entries");
                 println!("cargo:rustc-link-arg=-ltorch");
             }
+            "macos" => {
+                if let Some(lib_path) = std::env::var_os("DEP_TCH_LIBTORCH_LIB") {
+                    println!(
+                        "cargo:rustc-link-arg=-Wl,-rpath,{}",
+                        lib_path.to_string_lossy()
+                    );
+                }
+                println!("cargo:rustc-link-arg=-Wl,-undefined,dynamic_lookup");
+                println!("cargo:rustc-link-arg=-ltorch");
+                println!("cargo:rustc-link-arg=-ltorch_cpu");
+                println!("cargo:rustc-link-arg=-lc10");
+
+                // Link against Metal frameworks for MPS support
+                println!("cargo:rustc-link-arg=-framework");
+                println!("cargo:rustc-link-arg=Metal");
+                println!("cargo:rustc-link-arg=-framework");
+                println!("cargo:rustc-link-arg=MetalPerformanceShaders");
+                println!("cargo:rustc-link-arg=-framework");
+                println!("cargo:rustc-link-arg=Accelerate");
+            }
             _ => {}
         }
     }

--- a/shared/modeling/src/device_utils.rs
+++ b/shared/modeling/src/device_utils.rs
@@ -1,0 +1,218 @@
+use tch::{Device, Kind, Tensor};
+
+#[cfg(target_os = "macos")]
+pub fn has_mps() -> bool {
+    // Try to create a small tensor on MPS to verify it's actually available
+    // Use a panic catch to handle potential failures
+    std::panic::catch_unwind(|| {
+        let _tensor = Tensor::zeros(&[1], (Kind::Float, Device::Mps));
+        true
+    })
+    .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn has_mps() -> bool {
+    false
+}
+
+/// Check if CUDA is available
+pub fn has_cuda() -> bool {
+    tch::utils::has_cuda()
+}
+
+/// Get the optimal device for the current platform
+///
+/// Returns:
+/// - MPS on macOS if available
+/// - CUDA on other platforms if available
+/// - CPU as fallback
+pub fn get_optimal_device() -> Device {
+    #[cfg(target_os = "macos")]
+    {
+        if has_mps() {
+            return Device::Mps;
+        }
+    }
+
+    if has_cuda() {
+        Device::Cuda(0)
+    } else {
+        Device::Cpu
+    }
+}
+
+/// Parse device string into Device enum
+///
+/// Supported formats:
+/// - "cpu" -> Device::Cpu
+/// - "mps" -> Device::Mps (macOS only)
+/// - "cuda" -> Device::Cuda(0)
+/// - "cuda:N" -> Device::Cuda(N)
+pub fn parse_device(device_str: &str) -> anyhow::Result<Device> {
+    match device_str.to_lowercase().as_str() {
+        "cpu" => Ok(Device::Cpu),
+        "mps" => {
+            #[cfg(target_os = "macos")]
+            {
+                if has_mps() {
+                    Ok(Device::Mps)
+                } else {
+                    anyhow::bail!("MPS device requested but not available on this system")
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                anyhow::bail!("MPS device is only available on macOS")
+            }
+        }
+        "cuda" => Ok(Device::Cuda(0)),
+        s if s.starts_with("cuda:") => {
+            let id = s
+                .strip_prefix("cuda:")
+                .ok_or_else(|| anyhow::anyhow!("Invalid CUDA device format"))?
+                .parse::<usize>()
+                .map_err(|_| anyhow::anyhow!("Invalid CUDA device ID"))?;
+            Ok(Device::Cuda(id))
+        }
+        _ => anyhow::bail!(
+            "Invalid device: {}. Supported: cpu, mps, cuda, cuda:N",
+            device_str
+        ),
+    }
+}
+
+/// Get device for data parallel training.
+///
+/// On macOS with MPS, returns MPS for rank 0, CPU for others (MPS doesn't support multi-GPU).
+/// On other platforms, returns appropriate CUDA device
+pub fn get_device_for_rank(rank: usize, world_size: usize) -> Device {
+    #[cfg(target_os = "macos")]
+    {
+        if rank == 0 && has_mps() {
+            return Device::Mps;
+        } else if world_size > 1 {
+            return Device::Cpu;
+        }
+    }
+
+    if has_cuda() {
+        Device::Cuda(rank)
+    } else {
+        Device::Cpu
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_device() {
+        assert_eq!(parse_device("cpu").unwrap(), Device::Cpu);
+        assert_eq!(parse_device("CUDA:42").unwrap(), Device::Cuda(42));
+        assert!(parse_device("nvidia").is_err());
+        assert!(parse_device("").is_err());
+        assert!(parse_device("cuda:").is_err());
+        assert!(parse_device("cuda:abc").is_err());
+        assert!(parse_device("cuda:-1").is_err());
+        assert!(parse_device("cuda:1.5").is_err());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_mps_parsing_on_macos() {
+        let result = parse_device("mps");
+        if has_mps() {
+            assert_eq!(result.unwrap(), Device::Mps);
+        } else {
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("not available"));
+        }
+    }
+
+    #[test]
+    fn test_get_device_for_rank_single_worker() {
+        // Single worker should get optimal device
+        let device = get_device_for_rank(0, 1);
+
+        #[cfg(target_os = "macos")]
+        {
+            if has_mps() {
+                assert_eq!(device, Device::Mps);
+            } else {
+                assert_eq!(device, Device::Cpu);
+            }
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            if has_cuda() {
+                assert_eq!(device, Device::Cuda(0));
+            } else {
+                assert_eq!(device, Device::Cpu);
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_device_for_rank_multiple_workers() {
+        // Test multiple workers on different platforms
+        #[cfg(target_os = "macos")]
+        {
+            // On macOS with MPS, only rank 0 gets MPS
+            if has_mps() {
+                assert_eq!(get_device_for_rank(0, 4), Device::Mps);
+                assert_eq!(get_device_for_rank(1, 4), Device::Cpu);
+                assert_eq!(get_device_for_rank(2, 4), Device::Cpu);
+                assert_eq!(get_device_for_rank(3, 4), Device::Cpu);
+            }
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            if has_cuda() {
+                // Each rank gets its own CUDA device
+                assert_eq!(get_device_for_rank(0, 4), Device::Cuda(0));
+                assert_eq!(get_device_for_rank(1, 4), Device::Cuda(1));
+                assert_eq!(get_device_for_rank(2, 4), Device::Cuda(2));
+                assert_eq!(get_device_for_rank(3, 4), Device::Cuda(3));
+            } else {
+                // Without CUDA, everyone gets CPU
+                assert_eq!(get_device_for_rank(0, 4), Device::Cpu);
+                assert_eq!(get_device_for_rank(1, 4), Device::Cpu);
+            }
+        }
+    }
+
+    #[test]
+    fn test_optimal_device_consistency() {
+        // get_optimal_device should be consistent with get_device_for_rank(0, 1)
+        let optimal = get_optimal_device();
+        let rank_zero = get_device_for_rank(0, 1);
+        assert_eq!(optimal, rank_zero);
+    }
+
+    #[test]
+    fn test_device_functionality() {
+        // Test that we can actually create tensors on the returned devices
+        let device = get_optimal_device();
+
+        // This should not panic
+        let result = std::panic::catch_unwind(|| {
+            let tensor = Tensor::zeros(&[2, 3], (Kind::Float, device));
+            assert_eq!(tensor.size(), vec![2, 3]);
+            assert_eq!(tensor.device(), device);
+
+            // Test basic operations work
+            let result = &tensor + 1.0;
+            assert_eq!(result.size(), vec![2, 3]);
+        });
+
+        assert!(
+            result.is_ok(),
+            "Failed to create tensor on device {:?}",
+            device
+        );
+    }
+}

--- a/shared/modeling/src/lib.rs
+++ b/shared/modeling/src/lib.rs
@@ -4,6 +4,7 @@ mod auto_model;
 mod auto_tokenizer;
 mod batcher;
 mod causal_language_model;
+mod device_utils;
 mod distro;
 mod dummy;
 mod fp32_gradient_accumulator;
@@ -35,6 +36,7 @@ pub use causal_language_model::{
     CausalLM, CausalLanguageModel, EosToks, LanguageModelBuilder, LanguageModelConfig,
     LanguageModelForward,
 };
+pub use device_utils::{get_device_for_rank, get_optimal_device, has_cuda, has_mps, parse_device};
 pub use distro::{CompressDCT, Distro, DistroResult, TransformDCT};
 pub use dummy::{DummyModel, get_dummy_parameters};
 pub use fp32_gradient_accumulator::Fp32GradientAccumulator;


### PR DESCRIPTION
### Summary
This PR adds development environment support for macOS (Apple Silicon), enabling local development without requiring Linux/CUDA. Production deployments remain Linux/CUDA only.

 #### Limitations

- macOS support is development-only (no production deployments)
- Single GPU only (parallelism feature disabled -- NCCL not supported)
- Requires Apple Silicon for Metal Performance Shaders
- Some PyTorch operations may fall back to CPU if MPS kernels unavailable