### PR TITLE
allow preload during uninitialized state

### DIFF
--- a/architectures/decentralized/solana-client/src/main.rs
+++ b/architectures/decentralized/solana-client/src/main.rs
@@ -954,7 +954,10 @@ async fn async_main() -> Result<()> {
                 .state
                 .coordinator;
 
-            let is_paused = matches!(coordinator_account_state.run_state, RunState::Paused);
+            let is_paused = matches!(
+                coordinator_account_state.run_state,
+                RunState::Paused | RunState::Uninitialized
+            );
 
             if !is_paused {
                 let client_with_our_key = coordinator_account_state


### PR DESCRIPTION
When a run is first created its in the `Uninitialized` state not `Paused`, but we still want to be able to do preload then