### PR TITLE
ci: never build packages locally for docker image

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -12,20 +12,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Nix
-        uses: cachix/install-nix-action@v27
+      - uses: nixbuild/nix-quick-install-action@v31
         with:
-          extra_nix_config: |
+          nix_conf: |
+            download-buffer-size = 524288000
             accept-flake-config = true
-            substituters = https://cache.garnix.io https://cache.nixos.org/
-            trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://cache.nixos.org/ https://cache.garnix.io/ https://nix-community.cachix.org
+            trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
 
       - name: Download image from Garnix cache
         run: |
-          nix build .#docker-psyche-solana-client --no-link --print-out-paths > image-path.txt
-
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+          nix build --max-jobs 0 .#docker-psyche-solana-client --no-link --print-out-paths > image-path.txt
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
- they should all be pre-built
- remove a bunch of extra CI actions, speed up nix