### PR TITLE
fix running average min samples calc (backward comparison)

### DIFF
--- a/shared/core/src/running_average.rs
+++ b/shared/core/src/running_average.rs
@@ -34,7 +34,7 @@ impl AverageEntry {
     }
 
     fn average(&self) -> Option<f64> {
-        if self.buffer.len() >= self.min_samples {
+        if self.buffer.len() < self.min_samples {
             None
         } else {
             Some(self.sum / self.buffer.len() as f64)


### PR DESCRIPTION
wrong comparison direction for minimum samples