### PR TITLE
ci: bring narinfo cache ttl down to garnix value

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -19,6 +19,7 @@ jobs:
             accept-flake-config = true
             substituters = https://cache.nixos.org/ https://cache.garnix.io/ https://nix-community.cachix.org
             trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+            narinfo-cache-positive-ttl = 3600
 
       - name: Download image from Garnix cache
         run: |


### PR DESCRIPTION
this might have been causing docker CI failures, where the caches were already expired by the time the action tried to use them.