### PR TITLE
use flash attention 2

### DIFF
--- a/python/python/psyche/models/hf_transformers.py
+++ b/python/python/psyche/models/hf_transformers.py
@@ -117,7 +117,7 @@ class HfTransformersAuto(CausalLM):
 
         with torch.device("meta"):
             model: torch.nn.Module = AutoModelForCausalLM.from_config(
-                config,  # attn_implementation="flash_attention_2"
+                config, attn_implementation="flash_attention_2"
             )
         if device.type == "cuda":
             torch.cuda.set_device(device)


### PR DESCRIPTION
use attn_implementation='flash_attention_2' 
closes #199 

running the cmd now return correct results 
```
~/psyche$ nix develop .#dev-python --command cargo run --features parallelism,python --example train -- --model NousResearch/Meta-Llama-3.1-8B --data-path ./data/Hermes-3-Preprocessed-Llama3/data --data-parallelism 8 --micro-batch 1 --sequence-length 4096 --beta2 0.999 --total-batch 128 --learning-rate 0.000007 --warmup-steps 300 --weight-decay 0.01 --total-steps 2900 --python

2025-08-11T21:27:11.800738Z  INFO train: step: 1, duration: 15.14, loss: 0.8877
2025-08-11T21:27:23.953044Z  INFO train: step: 2, duration: 12.15, loss: 0.8913
2025-08-11T21:27:36.147032Z  INFO train: step: 3, duration: 12.19, loss: 0.9093
```