### PR TITLE
increase python nccl timeout

### DIFF
--- a/python/python/psyche/sidecar/__main__.py
+++ b/python/python/psyche/sidecar/__main__.py
@@ -102,6 +102,7 @@ def main():
         init_method=args.init_method,
         world_size=args.world_size,
         rank=args.rank if args.world_size else None,
+        timeout=timedelta(hours=2),
     )
 
     store = dist.distributed_c10d._get_default_store()

--- a/shared/modeling/src/python_distributed_causal_lm.rs
+++ b/shared/modeling/src/python_distributed_causal_lm.rs
@@ -10,6 +10,7 @@ use std::{
     process::{Child, Command},
     sync::Arc,
     thread::JoinHandle,
+    time::Duration,
 };
 use tch::{Device, Tensor};
 use thiserror::Error;
@@ -51,6 +52,7 @@ impl TorchDistributedCommunicator {
         let result: PyResult<PyObject> = Python::with_gil(|py| {
             let distributed = Python::import(py, "torch.distributed")?;
             let init_process_group = distributed.getattr("init_process_group")?;
+            let timeout = Duration::from_secs(60 * 60 * 2); // use a large timeout for warmup
             let kwargs = PyDict::new(py);
             if let Some(backend) = backend {
                 kwargs.set_item("backend", backend).unwrap();
@@ -64,6 +66,7 @@ impl TorchDistributedCommunicator {
             if let Some(rank) = rank {
                 kwargs.set_item("rank", rank).unwrap();
             }
+            kwargs.set_item("timeout", timeout).unwrap();
             init_process_group.call((), Some(&kwargs))?;
             let distributed_c10d = Python::import(py, "torch.distributed.distributed_c10d")?;
             let get_default_store = distributed_c10d.getattr("_get_default_store")?;


### PR DESCRIPTION
This increases the NCCL timeout that the Python sidecar waits for. The default one (10 minutes) is shorter than a potential warmup period, and since the sidecar main loop is driven by an NCCL wait, this could cause us to crash during warmup.