### PR TITLE
feat: implementing feedbacks on the CLI

### DIFF
--- a/architectures/decentralized/solana-client/src/backend.rs
+++ b/architectures/decentralized/solana-client/src/backend.rs
@@ -323,7 +323,7 @@ impl SolanaBackend {
         Ok(CreatedRun {
             instance: coordinator_instance,
             account: coordinator_account,
-            signature: signature,
+            signature,
         })
     }
 

--- a/architectures/decentralized/solana-client/src/backend.rs
+++ b/architectures/decentralized/solana-client/src/backend.rs
@@ -58,7 +58,7 @@ pub struct SolanaBackendRunner {
 pub struct CreatedRun {
     pub instance: Pubkey,
     pub account: Pubkey,
-    pub create_signatures: Vec<Signature>,
+    pub signature: Signature,
 }
 
 async fn subscribe_to_account(
@@ -284,7 +284,7 @@ impl SolanaBackend {
         let coordinator_account_signer = Keypair::new();
         let coordinator_account = coordinator_account_signer.pubkey();
 
-        let create_coordinator_signature = self.program_coordinators[0]
+        let signature = self.program_coordinators[0]
             .request()
             .instruction(system_instruction::create_account(
                 &payer,
@@ -323,7 +323,7 @@ impl SolanaBackend {
         Ok(CreatedRun {
             instance: coordinator_instance,
             account: coordinator_account,
-            create_signatures: vec![create_coordinator_signature],
+            signature: signature,
         })
     }
 

--- a/architectures/decentralized/solana-client/src/command/create_run.rs
+++ b/architectures/decentralized/solana-client/src/command/create_run.rs
@@ -1,9 +1,10 @@
+use std::str::FromStr;
+
 use anchor_client::solana_sdk::native_token::lamports_to_sol;
-use anchor_spl::associated_token;
+use anchor_client::solana_sdk::pubkey::Pubkey;
 use anyhow::Result;
+use anyhow::bail;
 use clap::Args;
-use serde_json::json;
-use serde_json::{to_string, Map};
 
 use crate::SolanaBackend;
 
@@ -41,8 +42,7 @@ pub async fn command_create_run_execute(
         treasurer_collateral_mint.map(|treasurer_collateral_mint| {
             let treasurer_index =
                 SolanaBackend::compute_deterministic_treasurer_index(&run_id, treasurer_index);
-            let treasurer_collateral_mint = treasurer_collateral_mint
-                .parse::<Pubkey>()
+            let treasurer_collateral_mint = Pubkey::from_str(&treasurer_collateral_mint)
                 .expect("Invalid collateral mint address");
             (treasurer_index, treasurer_collateral_mint)
         });

--- a/architectures/decentralized/solana-client/src/command/create_run.rs
+++ b/architectures/decentralized/solana-client/src/command/create_run.rs
@@ -34,7 +34,8 @@ pub async fn command_create_run_execute(
 
     if treasurer_index.is_some() && treasurer_collateral_mint.is_none() {
         bail!(
-            "treasurer_index is set, but treasurer_collateral_mint is not. Please provide a collateral mint address."
+            "The treasurer_index is set, but treasurer_collateral_mint is not. \
+            Please provide a collateral mint address if you want to create a run with a treasurer."
         );
     }
 

--- a/architectures/decentralized/solana-client/src/command/create_run.rs
+++ b/architectures/decentralized/solana-client/src/command/create_run.rs
@@ -1,0 +1,69 @@
+use anchor_client::solana_sdk::native_token::lamports_to_sol;
+use anchor_spl::associated_token;
+use anyhow::Result;
+use clap::Args;
+use serde_json::json;
+use serde_json::{to_string, Map};
+
+use crate::SolanaBackend;
+
+#[derive(Debug, Clone, Args)]
+#[command()]
+pub struct CommandCreateRunParams {
+    #[clap(short, long, env)]
+    run_id: String,
+    #[clap(long, env)]
+    treasurer_index: Option<u64>,
+    #[clap(long, env)]
+    treasurer_collateral_mint: Option<String>,
+    #[clap(long)]
+    join_authority: Option<String>,
+}
+
+pub async fn command_create_run_execute(
+    backend: SolanaBackend,
+    params: CommandCreateRunParams,
+) -> Result<()> {
+    let CommandCreateRunParams {
+        run_id,
+        treasurer_index,
+        treasurer_collateral_mint,
+        join_authority,
+    } = params;
+
+    if treasurer_index.is_some() && treasurer_collateral_mint.is_none() {
+        bail!(
+            "treasurer_index is set, but treasurer_collateral_mint is not. Please provide a collateral mint address."
+        );
+    }
+
+    let treasurer_index_and_collateral_mint =
+        treasurer_collateral_mint.map(|treasurer_collateral_mint| {
+            let treasurer_index =
+                SolanaBackend::compute_deterministic_treasurer_index(&run_id, treasurer_index);
+            let treasurer_collateral_mint = treasurer_collateral_mint
+                .parse::<Pubkey>()
+                .expect("Invalid collateral mint address");
+            (treasurer_index, treasurer_collateral_mint)
+        });
+
+    let created = backend
+        .create_run(
+            &run_id,
+            treasurer_index_and_collateral_mint,
+            join_authority.map(|address| Pubkey::from_str(&address).unwrap()),
+        )
+        .await?;
+
+    println!(
+        "Created run {} with transaction: {:?}",
+        run_id, created.signature,
+    );
+    println!("Instance account: {}", created.instance);
+    println!("Coordinator account: {}", created.account);
+
+    let locked = backend.get_balance(&created.account).await?;
+    println!("Locked for storage: {:.9} SOL", lamports_to_sol(locked));
+
+    Ok(())
+}

--- a/architectures/decentralized/solana-client/src/command/json_dump_run.rs
+++ b/architectures/decentralized/solana-client/src/command/json_dump_run.rs
@@ -160,7 +160,7 @@ pub async fn command_json_dump_run_execute(
             total_claimable_earned_points.saturating_sub(total_claimed_earned_points);
 
         let total_funded_unearned_points =
-            treasurer_run_collateral_amount.saturating_sub(total_unclaimed_earned_points);
+            i128::from(treasurer_run_collateral_amount) - i128::from(total_unclaimed_earned_points);
 
         let estimated_earned_points_per_epoch = u64::try_from(
             coordinator_account_state
@@ -179,7 +179,7 @@ pub async fn command_json_dump_run_execute(
         let estimated_funded_epochs_count = if estimated_earned_points_per_epoch == 0 {
             json!(f64::INFINITY)
         } else {
-            json!(total_funded_unearned_points / estimated_earned_points_per_epoch)
+            json!(total_funded_unearned_points / i128::from(estimated_earned_points_per_epoch))
         };
 
         Some(json!({

--- a/architectures/decentralized/solana-client/src/command/json_dump_run.rs
+++ b/architectures/decentralized/solana-client/src/command/json_dump_run.rs
@@ -1,9 +1,9 @@
 use anchor_spl::associated_token;
 use anyhow::Result;
 use clap::Args;
+use serde_json::Map;
 use serde_json::json;
 use serde_json::to_string_pretty;
-use serde_json::Map;
 
 use crate::SolanaBackend;
 

--- a/architectures/decentralized/solana-client/src/command/json_dump_run.rs
+++ b/architectures/decentralized/solana-client/src/command/json_dump_run.rs
@@ -1,9 +1,9 @@
 use anchor_spl::associated_token;
 use anyhow::Result;
 use clap::Args;
-use serde_json::Map;
 use serde_json::json;
 use serde_json::to_string_pretty;
+use serde_json::Map;
 
 use crate::SolanaBackend;
 
@@ -101,13 +101,11 @@ pub async fn command_json_dump_run_execute(
 
     let coordinator_account_json = json!({
         "address": coordinator_account_address.to_string(),
-        "metadata": {
-            "run_id": coordinator_account_state.state.coordinator.run_id,
-            "description": coordinator_account_state.state.metadata.description,
-            "name": coordinator_account_state.state.metadata.name,
-            "num_parameters": coordinator_account_state.state.metadata.num_parameters,
-            "vocab_size": coordinator_account_state.state.metadata.vocab_size,
-            "model": format!("{:?}", coordinator_account_state.state.coordinator.model),
+        "run_id": coordinator_account_state.state.coordinator.run_id,
+        "setup": {
+            "metadata": coordinator_account_state.state.metadata,
+            "model": coordinator_account_state.state.coordinator.model,
+            "config": coordinator_account_state.state.coordinator.config,
         },
         "status": {
             "next_active": coordinator_account_state.state.clients_state.next_active,

--- a/architectures/decentralized/solana-client/src/command/json_dump_user.rs
+++ b/architectures/decentralized/solana-client/src/command/json_dump_user.rs
@@ -77,7 +77,7 @@ pub async fn command_json_dump_user_execute(
         .state
         .coordinator
         .epoch_state
-        .clients
+        .exited_clients
     {
         if client.id.signer == address {
             epoch_exited_json = Some(json!({

--- a/architectures/decentralized/solana-client/src/command/json_dump_user.rs
+++ b/architectures/decentralized/solana-client/src/command/json_dump_user.rs
@@ -1,0 +1,139 @@
+use std::str::FromStr;
+
+use anchor_client::solana_sdk::pubkey::Pubkey;
+use anchor_spl::associated_token;
+use anyhow::Result;
+use clap::Args;
+use serde_json::json;
+use serde_json::to_string_pretty;
+
+use crate::SolanaBackend;
+
+#[derive(Debug, Clone, Args)]
+#[command()]
+pub struct CommandJsonDumpUserParams {
+    #[clap(short, long, env)]
+    run_id: String,
+    #[clap(long, env)]
+    treasurer_index: Option<u64>,
+    #[clap(long, env, alias = "wallet", value_name = "PUBKEY")]
+    address: String,
+}
+
+pub async fn command_json_dump_user_execute(
+    backend: SolanaBackend,
+    params: CommandJsonDumpUserParams,
+) -> Result<()> {
+    let CommandJsonDumpUserParams {
+        run_id,
+        treasurer_index,
+        address,
+    } = params;
+
+    let address = Pubkey::from_str(&address).expect("Invalid user address");
+    let balance = backend.get_balance(&address).await?;
+
+    let coordinator_instance_address =
+        psyche_solana_coordinator::find_coordinator_instance(&run_id);
+    let coordinator_instance_state = backend
+        .get_coordinator_instance(&coordinator_instance_address)
+        .await?;
+
+    let coordinator_account_address = coordinator_instance_state.coordinator_account;
+    let coordinator_account_state = backend
+        .get_coordinator_account(&coordinator_account_address)
+        .await?;
+
+    let mut client_json = None;
+    for client in coordinator_account_state.state.clients_state.clients {
+        if client.id.signer == address {
+            client_json = Some(json!({
+                "active": client.active,
+                "earned": client.earned,
+                "slashed": client.slashed,
+            }));
+            break;
+        }
+    }
+
+    let mut epoch_alive_json = None;
+    for client in coordinator_account_state
+        .state
+        .coordinator
+        .epoch_state
+        .clients
+    {
+        if client.id.signer == address {
+            epoch_alive_json = Some(json!({
+                "state": client.state,
+                "exited_height": client.exited_height,
+            }));
+            break;
+        }
+    }
+
+    let mut epoch_exited_json = None;
+    for client in coordinator_account_state
+        .state
+        .coordinator
+        .epoch_state
+        .clients
+    {
+        if client.id.signer == address {
+            epoch_exited_json = Some(json!({
+                "state": client.state,
+                "exited_height": client.exited_height,
+            }));
+            break;
+        }
+    }
+
+    let treasurer_participant_json = if let Some(treasurer_index) = backend
+        .resolve_treasurer_index(&run_id, treasurer_index)
+        .await?
+    {
+        let treasurer_run_address = psyche_solana_treasurer::find_run(treasurer_index);
+        let treasurer_run_state = backend.get_treasurer_run(&treasurer_run_address).await?;
+
+        let user_collateral_address = associated_token::get_associated_token_address(
+            &address,
+            &treasurer_run_state.collateral_mint,
+        );
+        let user_collateral_amount = backend
+            .get_token_amount(&user_collateral_address)
+            .await
+            .ok();
+
+        let treasurer_participant_address =
+            psyche_solana_treasurer::find_participant(&treasurer_run_address, &address);
+        let treasurer_participant_state = backend
+            .get_treasurer_participant(&treasurer_participant_address)
+            .await
+            .ok();
+
+        Some(json!({
+            "collateral_mint": treasurer_run_state.collateral_mint.to_string(),
+            "collateral_amount": user_collateral_amount,
+            "claimed_earned_points": treasurer_participant_state.as_ref().map(|state| state.claimed_earned_points),
+            "claimed_collateral_amount": treasurer_participant_state.as_ref().map(|state| state.claimed_collateral_amount),
+        }))
+    } else {
+        None
+    };
+
+    println!(
+        "{}",
+        to_string_pretty(&json!({
+            "address": address.to_string(),
+            "lamports": balance,
+            "coordinator_account": {
+                "client": client_json,
+                "epoch_alive": epoch_alive_json,
+                "epoch_exited": epoch_exited_json,
+            },
+            "treasurer_participant": treasurer_participant_json,
+        }))?
+    );
+
+    Ok(())
+}

--- a/architectures/decentralized/solana-client/src/command/json_info_dump.rs
+++ b/architectures/decentralized/solana-client/src/command/json_info_dump.rs
@@ -15,7 +15,7 @@ pub struct CommandJsonInfoDumpParams {
     treasurer_index: Option<u64>,
 }
 
-pub async fn command_json_info_dump_run(
+pub async fn command_json_info_dump_execute(
     backend: SolanaBackend,
     params: CommandJsonInfoDumpParams,
 ) -> Result<()> {
@@ -154,11 +154,11 @@ pub async fn command_json_info_dump_run(
             .await?;
 
         let total_claimable_earned_points = coordinator_account_clients_total_earned;
-        let total_unclaimed_earned_points =
-            total_claimable_earned_points - treasurer_run_state.total_claimed_earned_points;
+        let total_unclaimed_earned_points = total_claimable_earned_points
+            .saturating_sub(treasurer_run_state.total_claimed_earned_points);
 
         let total_funded_unearned_points =
-            treasurer_run_collateral_amount - total_unclaimed_earned_points;
+            treasurer_run_collateral_amount.saturating_sub(total_unclaimed_earned_points);
 
         let estimated_earned_points_per_epoch = u64::try_from(
             coordinator_account_state

--- a/architectures/decentralized/solana-client/src/command/mod.rs
+++ b/architectures/decentralized/solana-client/src/command/mod.rs
@@ -1,3 +1,4 @@
+pub mod create_run;
 pub mod json_info_dump;
 pub mod set_future_epoch_rates;
 pub mod treasurer_claim_rewards;

--- a/architectures/decentralized/solana-client/src/command/mod.rs
+++ b/architectures/decentralized/solana-client/src/command/mod.rs
@@ -1,5 +1,6 @@
 pub mod create_run;
-pub mod json_info_dump;
+pub mod json_dump_run;
+pub mod json_dump_user;
 pub mod set_future_epoch_rates;
 pub mod treasurer_claim_rewards;
 pub mod treasurer_top_up_rewards;

--- a/architectures/decentralized/solana-client/src/command/set_future_epoch_rates.rs
+++ b/architectures/decentralized/solana-client/src/command/set_future_epoch_rates.rs
@@ -16,7 +16,7 @@ pub struct CommandSetFutureEpochRatesParams {
     slashing_rate: Option<u64>,
 }
 
-pub async fn command_set_future_epoch_rates_run(
+pub async fn command_set_future_epoch_rates_execute(
     backend: SolanaBackend,
     params: CommandSetFutureEpochRatesParams,
 ) -> Result<()> {

--- a/architectures/decentralized/solana-client/src/command/treasurer_claim_rewards.rs
+++ b/architectures/decentralized/solana-client/src/command/treasurer_claim_rewards.rs
@@ -100,8 +100,11 @@ pub async fn command_treasurer_claim_rewards_execute(
         max_claimed_points.unwrap_or(u64::MAX),
     );
     if claim_earned_points > treasurer_run_collateral_amount {
-        return bail!(
-            "Claimed points ({claim_earned_points}) exceed funded collateral amount ({treasurer_run_collateral_amount}), specify a smaller value for --max-claimed-points or wait for more funding to be added to the run"
+        bail!(
+            "Claimed points ({claim_earned_points}) \
+            exceed available funded collateral ({treasurer_run_collateral_amount}), \
+            specify a smaller value with --max-claimed-points \
+            or wait for more funding to be top-up'd into the run's treasurer"
         );
     }
 

--- a/architectures/decentralized/solana-client/src/command/treasurer_top_up_rewards.rs
+++ b/architectures/decentralized/solana-client/src/command/treasurer_top_up_rewards.rs
@@ -15,7 +15,7 @@ pub struct CommandTreasurerTopUpRewardsParams {
     collateral_amount: u64,
 }
 
-pub async fn command_treasurer_top_up_rewards_run(
+pub async fn command_treasurer_top_up_rewards_execute(
     backend: SolanaBackend,
     params: CommandTreasurerTopUpRewardsParams,
 ) -> Result<()> {

--- a/architectures/decentralized/solana-client/src/main.rs
+++ b/architectures/decentralized/solana-client/src/main.rs
@@ -1,7 +1,9 @@
 use crate::command::create_run::CommandCreateRunParams;
 use crate::command::create_run::command_create_run_execute;
-use crate::command::json_info_dump::CommandJsonInfoDumpParams;
-use crate::command::json_info_dump::command_json_info_dump_execute;
+use crate::command::json_dump_run::CommandJsonDumpRunParams;
+use crate::command::json_dump_run::command_json_dump_run_execute;
+use crate::command::json_dump_user::CommandJsonDumpUserParams;
+use crate::command::json_dump_user::command_json_dump_user_execute;
 use crate::command::set_future_epoch_rates::CommandSetFutureEpochRatesParams;
 use crate::command::set_future_epoch_rates::command_set_future_epoch_rates_execute;
 use crate::command::treasurer_claim_rewards::CommandTreasurerClaimRewardsParams;
@@ -286,11 +288,17 @@ enum Commands {
         #[clap(long, env, default_value_t = 3)]
         hub_max_concurrent_downloads: usize,
     },
-    JsonInfoDump {
+    JsonDumpRun {
         #[clap(flatten)]
         cluster: ClusterArgs,
         #[clap(flatten)]
-        params: CommandJsonInfoDumpParams,
+        params: CommandJsonDumpRunParams,
+    },
+    JsonDumpUser {
+        #[clap(flatten)]
+        cluster: ClusterArgs,
+        #[clap(flatten)]
+        params: CommandJsonDumpUserParams,
     },
     // Prints the help, optionally as markdown. Used for docs generation.
     #[clap(hide = true)]
@@ -987,7 +995,7 @@ async fn async_main() -> Result<()> {
             }
             Ok(())
         }
-        Commands::JsonInfoDump { cluster, params } => {
+        Commands::JsonDumpRun { cluster, params } => {
             let backend = SolanaBackend::new(
                 cluster.into(),
                 vec![],
@@ -995,7 +1003,17 @@ async fn async_main() -> Result<()> {
                 CommitmentConfig::confirmed(),
             )
             .unwrap();
-            command_json_info_dump_execute(backend, params).await
+            command_json_dump_run_execute(backend, params).await
+        }
+        Commands::JsonDumpUser { cluster, params } => {
+            let backend = SolanaBackend::new(
+                cluster.into(),
+                vec![],
+                Keypair::new().into(),
+                CommitmentConfig::confirmed(),
+            )
+            .unwrap();
+            command_json_dump_user_execute(backend, params).await
         }
     }
 }

--- a/architectures/decentralized/solana-client/src/main.rs
+++ b/architectures/decentralized/solana-client/src/main.rs
@@ -1,12 +1,13 @@
+use crate::command::create_run::CommandCreateRunParams;
 use crate::command::create_run::command_create_run_execute;
 use crate::command::json_info_dump::CommandJsonInfoDumpParams;
-use crate::command::json_info_dump::command_json_info_dump_run;
+use crate::command::json_info_dump::command_json_info_dump_execute;
 use crate::command::set_future_epoch_rates::CommandSetFutureEpochRatesParams;
-use crate::command::set_future_epoch_rates::command_set_future_epoch_rates_run;
+use crate::command::set_future_epoch_rates::command_set_future_epoch_rates_execute;
 use crate::command::treasurer_claim_rewards::CommandTreasurerClaimRewardsParams;
-use crate::command::treasurer_claim_rewards::command_treasurer_claim_rewards_run;
+use crate::command::treasurer_claim_rewards::command_treasurer_claim_rewards_execute;
 use crate::command::treasurer_top_up_rewards::CommandTreasurerTopUpRewardsParams;
-use crate::command::treasurer_top_up_rewards::command_treasurer_top_up_rewards_run;
+use crate::command::treasurer_top_up_rewards::command_treasurer_top_up_rewards_execute;
 use crate::{
     app::{AppBuilder, AppParams, TAB_NAMES, Tabs},
     backend::SolanaBackend,
@@ -367,7 +368,7 @@ async fn async_main() -> Result<()> {
                 CommitmentConfig::confirmed(),
             )
             .unwrap();
-            command_create_run_execute(backend, params)
+            command_create_run_execute(backend, params).await
         }
         Commands::CloseRun {
             cluster,
@@ -594,7 +595,7 @@ async fn async_main() -> Result<()> {
                 CommitmentConfig::confirmed(),
             )
             .unwrap();
-            command_set_future_epoch_rates_run(backend, params).await
+            command_set_future_epoch_rates_execute(backend, params).await
         }
         Commands::TreasurerClaimRewards {
             cluster,
@@ -609,7 +610,7 @@ async fn async_main() -> Result<()> {
                 CommitmentConfig::confirmed(),
             )
             .unwrap();
-            command_treasurer_claim_rewards_run(backend, params).await
+            command_treasurer_claim_rewards_execute(backend, params).await
         }
         Commands::TreasurerTopUpRewards {
             cluster,
@@ -624,7 +625,7 @@ async fn async_main() -> Result<()> {
                 CommitmentConfig::confirmed(),
             )
             .unwrap();
-            command_treasurer_top_up_rewards_run(backend, params).await
+            command_treasurer_top_up_rewards_execute(backend, params).await
         }
         Commands::Checkpoint {
             cluster,
@@ -994,7 +995,7 @@ async fn async_main() -> Result<()> {
                 CommitmentConfig::confirmed(),
             )
             .unwrap();
-            command_json_info_dump_run(backend, params).await
+            command_json_info_dump_execute(backend, params).await
         }
     }
 }

--- a/psyche-book/src/enduser/create-run.md
+++ b/psyche-book/src/enduser/create-run.md
@@ -132,6 +132,6 @@ For more info about a specific user inside of a run, you can also use:
 ```bash
 psyche-solana-client json-dump-user \
     --rpc [RPC] \
-    --run-id [RUN_ID]
+    --run-id [RUN_ID] \
     --wallet [PUBLIC_KEY]
 ```

--- a/psyche-book/src/enduser/create-run.md
+++ b/psyche-book/src/enduser/create-run.md
@@ -122,7 +122,16 @@ psyche-solana-client treasurer-top-up-rewards \
 Optionally you can get detailled technical information about a run that was previously created for troubleshooting purposes.
 
 ```bash
-psyche-solana-client json-info-dump \
+psyche-solana-client json-dump-run \
     --rpc [RPC] \
     --run-id [RUN_ID]
+```
+
+For more info about a specific user inside of a run, you can also use:
+
+```bash
+psyche-solana-client json-dump-user \
+    --rpc [RPC] \
+    --run-id [RUN_ID]
+    --wallet [PUBLIC_KEY]
 ```


### PR DESCRIPTION
## Summary

Follow-up on feedbacks made about the CLI, small improvements all around.

Note: Adds a `json-dump-user` command (to go with `json-dump-run`)

## Details

Addresses:

 - https://github.com/PsycheFoundation/psyche/issues/247
 - https://github.com/PsycheFoundation/psyche/issues/246
 - https://github.com/PsycheFoundation/psyche/issues/22
 
Also adds a new CLI command to dump information about a user client in particular (within a run). Separate from the command to dump information about the run itself.