### PR TITLE
evals: improve fewshot

### DIFF
--- a/shared/eval/src/harness.rs
+++ b/shared/eval/src/harness.rs
@@ -13,7 +13,7 @@ use std::{collections::HashMap, fmt::Display, sync::Arc};
 use tch::{Kind, Tensor};
 use tokenizers::Tokenizer;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info};
+use tracing::info;
 const GENERATE_UNTIL_MAX_TOKENS: usize = 600;
 const MAX_CONTEXT_SIZE: usize = 2048;
 
@@ -61,7 +61,6 @@ impl Display for Task {
 enum PreparedTaskType {
     LogLikelihood {
         docs: Vec<TokenizedLLHDocument>,
-        tokenized_fewshot: Vec<i64>,
     },
     GenerateUntil {
         requests: Vec<TokenizedGenerateUntilDocument>,
@@ -102,7 +101,7 @@ pub struct TokenizedGenerateUntilDocument {
 }
 
 impl TokenizedLLHDocument {
-    pub fn from_document(doc: Document, tokenizer: &Tokenizer) -> Self {
+    pub fn from_document(doc: Document, tokenizer: &Tokenizer, fewshot_prefix: &str) -> Self {
         // e.g.
         // choice: 'Sunlight is the source of energy for nearly all ecosystems.'
         // text: 'Which statement best explains why photosynthesis is the foundation of most food webs?'
@@ -112,22 +111,37 @@ impl TokenizedLLHDocument {
         let mut choices_token_len = Vec::new();
         let mut choices: Vec<Vec<i64>> = Vec::new();
 
+        // Tokenize fewshot prefix once
+        let fewshot_tokens: Vec<i64> = tokenizer
+            .encode(fewshot_prefix, false)
+            .unwrap()
+            .get_ids()
+            .iter()
+            .map(|x| *x as i64)
+            .collect();
+
         for choice in doc.choices.iter() {
             choices_str.push(choice.clone());
 
-            let request = tokenizer
-                .encode(format!("{} {}", doc.text, choice), false)
+            // [fewshot_prefix] + [document_text + choice]
+            let text_and_choice = format!("{} {}", doc.text, choice);
+            let text_choice_tokens: Vec<i64> = tokenizer
+                .encode(text_and_choice, false)
                 .unwrap()
                 .get_ids()
                 .iter()
                 .map(|x| *x as i64)
-                .collect::<Vec<_>>();
-            requests.push(request.clone());
+                .collect();
 
+            let mut full_request = fewshot_tokens.clone();
+            full_request.extend_from_slice(&text_choice_tokens);
+            requests.push(full_request.clone());
+
+            // Extract choice tokens from the text_choice_tokens part
             // Tokenizing "choice" alone produces different tokens than tokenizing "text + choice" together.
             // So, we extract choice tokens iterating the full request backwards to ensure exact matching.
-            for idx in 1..request.len() {
-                let choice_tokens = &request[request.len() - idx..]
+            for idx in 1..text_choice_tokens.len() {
+                let choice_tokens = &text_choice_tokens[text_choice_tokens.len() - idx..]
                     .iter()
                     .map(|x| *x as u32)
                     .collect::<Vec<_>>();
@@ -136,18 +150,9 @@ impl TokenizedLLHDocument {
                     let choice_tokens = choice_tokens.iter().map(|x| *x as i64).collect::<Vec<_>>();
                     choices.push(choice_tokens.clone());
                     choices_token_len.push(choice_tokens.len());
-
                     break;
                 }
             }
-        }
-
-        // verify correctness
-        for x in 0..requests.len() {
-            debug_assert_eq!(
-                requests[x][requests[x].len() - choices_token_len[x]..],
-                choices[x]
-            );
         }
 
         Self {
@@ -170,38 +175,46 @@ impl Task {
                 if let Some(limit) = limit {
                     docs.truncate(limit);
                 }
-                let fewshot = if self.num_fewshot > 0 {
-                    let mut fewshot_docs = llh.get_fewshot_documents();
-                    fewshot_docs.shuffle(&mut self.rand);
-                    fewshot_docs
-                        .into_iter()
-                        .take(self.num_fewshot)
-                        .map(|x| format!("{}{}", x.text, x.choices[x.answer]))
-                        .collect::<Vec<_>>()
-                        .join("\n\n")
-                        + "\n\n"
-                } else {
-                    String::new()
-                };
+                let fewshot_by_category = llh.get_fewshot_documents();
 
-                let tokenized_fewshot = tokenizer
-                    .encode(fewshot, false)
-                    .unwrap()
-                    .get_ids()
-                    .iter()
-                    .map(|x| *x as i64)
-                    .collect::<Vec<_>>();
+                // Build individual requests with category-specific fewshot for each document
                 let docs = docs
                     .into_iter()
-                    .map(|x| TokenizedLLHDocument::from_document(x, tokenizer))
+                    .map(|doc| {
+                        // Build fewshot prefix for this document
+                        let fewshot_prefix = if self.num_fewshot > 0 {
+                            // Get fewshot examples for this document's category
+                            let category = doc.category.as_deref().unwrap_or("default");
+                            let mut fewshot_examples = fewshot_by_category
+                                .get(category)
+                                .cloned()
+                                .unwrap_or_else(|| {
+                                    // Fallback: use first available category if document's category is not found
+                                    fewshot_by_category
+                                        .values()
+                                        .next()
+                                        .cloned()
+                                        .unwrap_or_else(Vec::new)
+                                });
+                            fewshot_examples.shuffle(&mut self.rand);
+                            fewshot_examples
+                                .into_iter()
+                                .take(self.num_fewshot)
+                                .map(|x| format!("{}{}", x.text, x.choices[x.answer]))
+                                .collect::<Vec<_>>()
+                                .join("\n\n")
+                                + "\n\n"
+                        } else {
+                            String::new()
+                        };
+
+                        TokenizedLLHDocument::from_document(doc, tokenizer, &fewshot_prefix)
+                    })
                     .collect::<Vec<_>>();
                 PreparedTask {
                     name,
                     num: docs.len(),
-                    prepared_task_type: PreparedTaskType::LogLikelihood {
-                        docs,
-                        tokenized_fewshot,
-                    },
+                    prepared_task_type: PreparedTaskType::LogLikelihood { docs },
                 }
             }
             TaskType::GenerateUntil(gu_docs) => {
@@ -325,10 +338,9 @@ impl PreparedTask {
         };
 
         match &self.prepared_task_type {
-            PreparedTaskType::LogLikelihood {
-                docs,
-                tokenized_fewshot,
-            } => Self::run_log_likelihood(&self.name, options, docs, tokenized_fewshot, pbar),
+            PreparedTaskType::LogLikelihood { docs } => {
+                Self::run_log_likelihood(&self.name, options, docs, pbar)
+            }
             PreparedTaskType::GenerateUntil {
                 requests,
                 tokenizer,
@@ -350,7 +362,6 @@ impl PreparedTask {
         eval_name: &String,
         options: EvalTaskOptions,
         docs: &[TokenizedLLHDocument],
-        tokenized_fewshot: &[i64],
         pbar: Option<ProgressBar>,
     ) -> PreparedTaskResult {
         let results = options.live_results.unwrap_or_default();
@@ -408,19 +419,9 @@ impl PreparedTask {
                 // request: 'Which statement best explains why photosynthesis is the foundation of most food webs? Sunlight is the source of energy for nearly all ecosystems'
                 request.pop();
 
-                // [fewshot_tokens] + [question + choice_without_last_token]
-                let mut full_request = tokenized_fewshot.to_vec();
-                full_request.extend_from_slice(&request);
+                // The request already contains [fewshot_tokens] + [question + choice_without_last_token]
+                let full_request = request;
                 let input_length = &full_request.len();
-
-                // These are conditions that probably shouldn't happen
-                if tokenized_fewshot.is_empty() {
-                    debug!("run_log_likelihood: Fewshot tokens are empty");
-                } else if full_request.len() > request.len() {
-                    debug!(
-                        "run_log_likelihood: Fewshot tokens should increase request length but they did not"
-                    );
-                }
 
                 let request_tensor = Tensor::from_slice(&full_request)
                     .to(options.model.device())
@@ -437,8 +438,7 @@ impl PreparedTask {
 
                 // Get tensor of shape `[choice.len(), vocab_size]` containing the
                 // model's logits for each token of the `choice` text.
-                // Account for fewshot prefix: we want the logits for the choice tokens
-                // which are at the end of our full_request
+                // This should skip the fewshot tokens and get the tokens from the end.
                 let logits = logits.slice(
                     0,
                     *input_length as i64 - choice.len() as i64,

--- a/shared/eval/src/tasks/arc.rs
+++ b/shared/eval/src/tasks/arc.rs
@@ -1,7 +1,7 @@
 use crate::{TaskType, load_dataset, traits::Document, traits::LogLikelihoodTask};
 use anyhow::Result;
 use psyche_data_provider::{Dataset, Field, Row, RowAccessor, Split};
-use std::fmt::Display;
+use std::{collections::HashMap, fmt::Display};
 
 struct Arc {
     test_split: Dataset,
@@ -86,11 +86,15 @@ impl LogLikelihoodTask for Arc {
             .collect()
     }
 
-    fn get_fewshot_documents(&self) -> Vec<Document> {
-        self.validation_dataset
+    fn get_fewshot_documents(&self) -> HashMap<String, Vec<Document>> {
+        let mut fewshot_documents = HashMap::new();
+        let docs: Vec<Document> = self
+            .validation_dataset
             .iter()
             .map(|row| Arc::row_to_document(&self.validation_dataset, row))
-            .collect()
+            .collect();
+        fewshot_documents.insert("default".to_string(), docs);
+        fewshot_documents
     }
 }
 
@@ -115,7 +119,7 @@ impl LogLikelihoodTask for ArcEasy {
         self.task.get_documents()
     }
 
-    fn get_fewshot_documents(&self) -> Vec<Document> {
+    fn get_fewshot_documents(&self) -> HashMap<String, Vec<Document>> {
         self.task.get_fewshot_documents()
     }
 }
@@ -141,7 +145,7 @@ impl LogLikelihoodTask for ArcChallenge {
         self.task.get_documents()
     }
 
-    fn get_fewshot_documents(&self) -> Vec<Document> {
+    fn get_fewshot_documents(&self) -> HashMap<String, Vec<Document>> {
         self.task.get_fewshot_documents()
     }
 }

--- a/shared/eval/src/tasks/boolq.rs
+++ b/shared/eval/src/tasks/boolq.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use anyhow::Result;
 use psyche_data_provider::{Dataset, Row, RowAccessor, Split};
-use std::fmt::Display;
+use std::{collections::HashMap, fmt::Display};
 
 pub struct BoolQ {
     test_dataset: Dataset,
@@ -79,11 +79,15 @@ impl LogLikelihoodTask for BoolQ {
             .collect()
     }
 
-    fn get_fewshot_documents(&self) -> Vec<Document> {
-        self.test_dataset
+    fn get_fewshot_documents(&self) -> HashMap<String, Vec<Document>> {
+        let mut fewshot_documents = HashMap::new();
+        let docs: Vec<Document> = self
+            .test_dataset
             .iter()
             .map(|row| BoolQ::row_to_document(&self.test_dataset, row))
-            .collect()
+            .collect();
+        fewshot_documents.insert("default".to_string(), docs);
+        fewshot_documents
     }
 }
 

--- a/shared/eval/src/tasks/hellaswag.rs
+++ b/shared/eval/src/tasks/hellaswag.rs
@@ -14,7 +14,7 @@ use crate::{
 use anyhow::Result;
 use psyche_data_provider::{Dataset, ListAccessor, Row, RowAccessor, Split};
 use regex::Regex;
-use std::fmt::Display;
+use std::{collections::HashMap, fmt::Display};
 
 fn preprocess(text: &str) -> String {
     let mut processed = text.trim().to_string();
@@ -80,7 +80,7 @@ impl Hellaswag {
             text,
             choices,
             answer,
-            category: None,
+            category: Some(activity_label),
             cot_content: None,
         }
     }
@@ -94,11 +94,18 @@ impl LogLikelihoodTask for Hellaswag {
             .collect()
     }
 
-    fn get_fewshot_documents(&self) -> Vec<Document> {
-        self.train_dataset
-            .iter()
-            .map(|row| Hellaswag::row_to_document(&self.train_dataset, row))
-            .collect()
+    fn get_fewshot_documents(&self) -> HashMap<String, Vec<Document>> {
+        let mut fewshot_documents = HashMap::new();
+        self.train_dataset.iter().for_each(|row| {
+            let doc = Hellaswag::row_to_document(&self.train_dataset, row);
+            if let Some(category) = &doc.category {
+                fewshot_documents
+                    .entry(category.clone())
+                    .or_insert_with(Vec::new)
+                    .push(doc);
+            }
+        });
+        fewshot_documents
     }
 }
 

--- a/shared/eval/src/tasks/openbookqa.rs
+++ b/shared/eval/src/tasks/openbookqa.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use anyhow::Result;
 use psyche_data_provider::{Dataset, ListAccessor, Row, RowAccessor, Split};
-use std::fmt::Display;
+use std::{collections::HashMap, fmt::Display};
 
 pub struct OpenbookQA {
     test_dataset: Dataset,
@@ -92,11 +92,15 @@ impl LogLikelihoodTask for OpenbookQA {
             .collect()
     }
 
-    fn get_fewshot_documents(&self) -> Vec<Document> {
-        self.validation_dataset
+    fn get_fewshot_documents(&self) -> HashMap<String, Vec<Document>> {
+        let mut fewshot_documents = HashMap::new();
+        let docs: Vec<Document> = self
+            .validation_dataset
             .iter()
             .map(|row| OpenbookQA::row_to_document(&self.validation_dataset, row))
-            .collect()
+            .collect();
+        fewshot_documents.insert("default".to_string(), docs);
+        fewshot_documents
     }
 }
 

--- a/shared/eval/src/tasks/piqa.rs
+++ b/shared/eval/src/tasks/piqa.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use anyhow::Result;
 use psyche_data_provider::{Dataset, Row, RowAccessor, Split};
-use std::fmt::Display;
+use std::{collections::HashMap, fmt::Display};
 
 pub struct PIQA {
     train_dataset: Dataset,
@@ -65,11 +65,15 @@ impl LogLikelihoodTask for PIQA {
             .collect()
     }
 
-    fn get_fewshot_documents(&self) -> Vec<Document> {
-        self.train_dataset
+    fn get_fewshot_documents(&self) -> HashMap<String, Vec<Document>> {
+        let mut fewshot_documents = HashMap::new();
+        let docs: Vec<Document> = self
+            .train_dataset
             .iter()
             .map(|row| PIQA::row_to_document(&self.train_dataset, row))
-            .collect()
+            .collect();
+        fewshot_documents.insert("default".to_string(), docs);
+        fewshot_documents
     }
 }
 

--- a/shared/eval/src/traits.rs
+++ b/shared/eval/src/traits.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fmt::Display};
 
+#[derive(Clone)]
 pub struct Document {
     pub text: String,
     pub choices: Vec<String>,
@@ -10,7 +11,7 @@ pub struct Document {
 
 pub trait LogLikelihoodTask: Send + Display {
     fn get_documents(&self) -> Vec<Document>;
-    fn get_fewshot_documents(&self) -> Vec<Document>;
+    fn get_fewshot_documents(&self) -> HashMap<String, Vec<Document>>;
 }
 
 pub trait GenerateUntilTask: Send + Display {


### PR DESCRIPTION
If you look at the previous code currently in main apparently we do not use `context` for anything, in this PR I attempted to use it in the prompt so that the model gets the actual fewshot context alongside the prompt and options.

We also try to use fewshot from the same category as the question.

I've run some simple benchmarks and it doesn't seem to improve too much if at all, depending on the task, but it seems weird to not use the context for anything. Currently in `main` adding fewshots does not modify the accuracy at all, and now they do.

Closes #223 

<img width="531" height="270" alt="image" src="https://github.com/user-attachments/assets/2735d66d-18ec-4c80-80bf-833d0095a21c" />
