### PR TITLE
bug: don't use uvloop for c10d store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7466,6 +7466,7 @@ dependencies = [
  "tch",
  "tokio-util 0.7.15",
  "torch-sys",
+ "tracing",
 ]
 
 [[package]]

--- a/python/extension-impl/Cargo.toml
+++ b/python/extension-impl/Cargo.toml
@@ -14,6 +14,7 @@ pyo3.workspace = true
 pyo3-tch.workspace = true
 sysinfo = "0.30"
 take_mut = "0.2.2"
+tracing.workspace = true
 
 [features]
 parallelism = ["psyche-modeling/parallelism"]

--- a/python/extension-impl/src/extension.rs
+++ b/python/extension-impl/src/extension.rs
@@ -12,6 +12,7 @@ use std::{
 };
 use sysinfo::{Pid, System};
 use tokio_util::sync::CancellationToken;
+use tracing::trace;
 
 #[pyfunction]
 fn add_one(tensor: PyTensor) -> PyResult<PyTensor> {
@@ -156,6 +157,7 @@ impl Trainer {
         warmup_lr_between: Option<(u32, u32)>,
         prev_self_distro_results: Option<Vec<Vec<Py<DistroResult>>>>,
     ) -> PyResult<(Option<Vec<DistroResult>>, f32)> {
+        trace!("Python extension train() for step {step}");
         let trainer = self_.trainer.write().unwrap().take().unwrap();
         let id = BatchId(ClosedInterval::new(batch_id.0, batch_id.1));
         let cancel = self_.cancel.clone();
@@ -215,6 +217,7 @@ impl Trainer {
         warmup_lr_between: Option<(u32, u32)>,
         distro_results: Option<Vec<Vec<Py<DistroResult>>>>,
     ) -> PyResult<()> {
+        trace!("Python extension optimize() for step {step}");
         let trainer = self_.trainer.write().unwrap().take().unwrap();
         let distro_results = DistroResult::to_native(self_.py(), distro_results)?;
         let output = self_

--- a/shared/modeling/src/python_distributed_trainer.rs
+++ b/shared/modeling/src/python_distributed_trainer.rs
@@ -177,7 +177,10 @@ impl PythonDistributedTrainer {
             "results_metadata": prev_self_distro_results.as_ref().map(|r| Self::distro_results_metadata(r)),
         });
 
-        trace!("Sending train operation to Python clients: {}", operation);
+        trace!(
+            "Sending train operation to Python clients, iteration = {}",
+            self.iteration
+        );
 
         self.comm
             .set(&self.iteration.to_string(), &operation.to_string())?;
@@ -311,8 +314,8 @@ impl PythonDistributedTrainer {
         });
 
         trace!(
-            "Sending optimize operation to Python clients: {}",
-            operation
+            "Sending optimize operation to Python clients, iteration = {}",
+            self.iteration
         );
 
         self.comm


### PR DESCRIPTION
This fixes an extremely difficult to track down bug where some Python runs would inexplicably (but reproducibly) stall when using FSDPv2. Although the reason is unclear, the error came down to the c10d store server in the Rust process not properly updating Python clients. Disabling the uvloop backend in Python and using the legacy direct socket backend fixes it. I assume it's some evil interaction between the Rust system and uvloop