### PR TITLE
get rid of pin deprecation warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7669,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "pyo3-tch"
 version = "0.21.0"
-source = "git+https://github.com/jquesnelle/tch-rs.git?rev=8600b2c90a443e5ac1edf6981455c26d4c5388e2#8600b2c90a443e5ac1edf6981455c26d4c5388e2"
+source = "git+https://github.com/jquesnelle/tch-rs.git?rev=a7ad43a4c0ca62674f07b14786ed42b5c2ccdea1#a7ad43a4c0ca62674f07b14786ed42b5c2ccdea1"
 dependencies = [
  "pyo3",
  "tch",
@@ -12071,7 +12071,7 @@ dependencies = [
 [[package]]
 name = "tch"
 version = "0.21.0"
-source = "git+https://github.com/jquesnelle/tch-rs.git?rev=8600b2c90a443e5ac1edf6981455c26d4c5388e2#8600b2c90a443e5ac1edf6981455c26d4c5388e2"
+source = "git+https://github.com/jquesnelle/tch-rs.git?rev=a7ad43a4c0ca62674f07b14786ed42b5c2ccdea1#a7ad43a4c0ca62674f07b14786ed42b5c2ccdea1"
 dependencies = [
  "half",
  "lazy_static",
@@ -12554,7 +12554,7 @@ dependencies = [
 [[package]]
 name = "torch-sys"
 version = "0.21.0"
-source = "git+https://github.com/jquesnelle/tch-rs.git?rev=8600b2c90a443e5ac1edf6981455c26d4c5388e2#8600b2c90a443e5ac1edf6981455c26d4c5388e2"
+source = "git+https://github.com/jquesnelle/tch-rs.git?rev=a7ad43a4c0ca62674f07b14786ed42b5c2ccdea1#a7ad43a4c0ca62674f07b14786ed42b5c2ccdea1"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,9 +79,9 @@ indicatif = "0.17.5"
 tokenizers = { version = "0.20.0", default-features = false, features = [
   "onig",
 ] }
-tch = { git = "https://github.com/jquesnelle/tch-rs.git", rev = "8600b2c90a443e5ac1edf6981455c26d4c5388e2" }
-torch-sys = { git = "https://github.com/jquesnelle/tch-rs.git", rev = "8600b2c90a443e5ac1edf6981455c26d4c5388e2" }
-pyo3-tch = { git = "https://github.com/jquesnelle/tch-rs.git", rev = "8600b2c90a443e5ac1edf6981455c26d4c5388e2" }
+tch = { git = "https://github.com/jquesnelle/tch-rs.git", rev = "a7ad43a4c0ca62674f07b14786ed42b5c2ccdea1" }
+torch-sys = { git = "https://github.com/jquesnelle/tch-rs.git", rev = "a7ad43a4c0ca62674f07b14786ed42b5c2ccdea1" }
+pyo3-tch = { git = "https://github.com/jquesnelle/tch-rs.git", rev = "a7ad43a4c0ca62674f07b14786ed42b5c2ccdea1" }
 #tch = { path = "../tch-rs" }
 #torch-sys = { path = "../tch-rs/torch-sys" }
 #pyo3-tch = { path = "../tch-rs/pyo3-tch" }

--- a/shared/network/src/serialized_distro.rs
+++ b/shared/network/src/serialized_distro.rs
@@ -78,12 +78,11 @@ impl TryFrom<&SerializedDistroResult> for DistroResult {
             totalk: value.totalk as i64,
             stats: None,
         };
-        // don't always pin - it would crash if no CUDA is available.
+        // only pin if we have a device to pin to
         let potential_cuda_device = Device::cuda_if_available();
         if potential_cuda_device.is_cuda() {
-            // the index of the CUDA device doesn't matter here.
-            distro_result.sparse_idx = distro_result.sparse_idx.pin_memory(potential_cuda_device);
-            distro_result.sparse_val = distro_result.sparse_val.pin_memory(potential_cuda_device);
+            distro_result.sparse_idx = distro_result.sparse_idx.pin_memory();
+            distro_result.sparse_val = distro_result.sparse_val.pin_memory();
         }
         Ok(distro_result)
     }


### PR DESCRIPTION
updated tch-rs to use the new non-device-passing pin fn calls