### PR TITLE
evals: fix progress bars when DP>1

### DIFF
--- a/shared/client/src/state/evals.rs
+++ b/shared/client/src/state/evals.rs
@@ -70,6 +70,7 @@ impl EvalTask {
                 live_results: Some(self.results.clone()),
                 cancel: Some(cancel),
                 limit,
+                shared_progress_bar: None,
             },
             false,
         );

--- a/shared/eval/examples/evaluate.rs
+++ b/shared/eval/examples/evaluate.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
 use clap::Parser;
+use indicatif::{ProgressBar, ProgressStyle};
 use psyche_core::RunningAverage;
 use psyche_data_provider::download_model_repo_sync;
-use psyche_eval::{ALL_TASK_NAMES, EvalTaskOptions, Task, tasktype_from_name};
+use psyche_eval::{
+    ALL_TASK_NAMES, EvalTaskOptions, Task, progress_bar_template_with_task, tasktype_from_name,
+};
 use psyche_modeling::{CausalLM, auto_model_for_causal_lm_from_pretrained, auto_tokenizer};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -132,11 +135,36 @@ fn run_data_parallel(
         data_parallelism
     };
 
+    let shared_progress_bars: Vec<Option<Arc<ProgressBar>>> = if !quiet && threads > 1 {
+        task_info
+            .iter()
+            .map(|(task_name, _, _)| {
+                // Get the prepared task to determine total number of items
+                let task_type = tasktype_from_name(task_name).ok()?;
+                let task = Task::new(task_type, num_fewshot, seed);
+                let prepared_task = task.prepare(&tokenizer, None);
+
+                println!("Running {} with {} parallel threads", task_name, threads);
+                let pbar = ProgressBar::new(prepared_task.num as u64);
+                pbar.set_style(
+                    ProgressStyle::default_bar()
+                        .template(&progress_bar_template_with_task(task_name))
+                        .unwrap()
+                        .progress_chars("#>-"),
+                );
+                Some(Arc::new(pbar))
+            })
+            .collect()
+    } else {
+        task_info.iter().map(|_| None).collect()
+    };
+
     let mut gpu_handles: Vec<JoinHandle<Result<()>>> = vec![];
     for gpu_id in 0..threads {
         let repo = repo.clone();
         let tokenizer = tokenizer.clone();
         let shared_results = shared_results.clone();
+        let shared_progress_bars = shared_progress_bars.clone();
         let task_info = task_info.clone();
 
         let handle = std::thread::spawn(move || -> Result<()> {
@@ -189,6 +217,7 @@ fn run_data_parallel(
                         live_results: Some(shared_results[task_idx].clone()),
                         cancel: None,
                         limit: None,
+                        shared_progress_bar: shared_progress_bars[task_idx].clone(),
                     },
                     !quiet,
                 );

--- a/shared/eval/src/lib.rs
+++ b/shared/eval/src/lib.rs
@@ -5,7 +5,10 @@ mod harness;
 mod tasks;
 mod traits;
 
-pub use harness::{EvalTaskOptions, PreparedTask, PreparedTaskResult, Task, TaskType};
+pub use harness::{
+    EvalTaskOptions, PROGRESS_BAR_TEMPLATE, PreparedTask, PreparedTaskResult, Task, TaskType,
+    progress_bar_template_with_task,
+};
 pub use tasks::{ArcChallenge, ArcEasy, BoolQ, Hellaswag, MMLU, MMLUPro, OpenbookQA, PIQA};
 
 pub const ASCII_UPPERCASE: [&str; 26] = [


### PR DESCRIPTION
When running the evaluation example with DP>1 the progress bars were duplicated and not being updated.

Now we just show a single bar with the shared progress between threads.

<img width="829" height="147" alt="image" src="https://github.com/user-attachments/assets/d8e0d906-74be-4dce-aad1-f0f28bcb447b" />

Closes #282 