### PR TITLE
fix: health-check speculative hotfix

### DIFF
--- a/architectures/decentralized/solana-client/src/backend.rs
+++ b/architectures/decentralized/solana-client/src/backend.rs
@@ -319,9 +319,11 @@ impl SolanaBackend {
         id: psyche_solana_coordinator::ClientId,
         check: CommitteeProof,
     ) {
+        let user = self.get_payer();
         let instruction = instructions::coordinator_health_check(
             &coordinator_instance,
             &coordinator_account,
+            &user,
             id,
             check,
         );

--- a/architectures/decentralized/solana-client/src/instructions.rs
+++ b/architectures/decentralized/solana-client/src/instructions.rs
@@ -202,13 +202,14 @@ pub fn coordinator_warmup_witness(
 pub fn coordinator_health_check(
     coordinator_instance: &Pubkey,
     coordinator_account: &Pubkey,
+    user: &Pubkey,
     client_id: psyche_solana_coordinator::ClientId,
     check: psyche_coordinator::CommitteeProof,
 ) -> Instruction {
     anchor_instruction(
         psyche_solana_coordinator::ID,
         psyche_solana_coordinator::accounts::PermissionlessCoordinatorAccounts {
-            user: client_id.signer,
+            user: *user,
             coordinator_instance: *coordinator_instance,
             coordinator_account: *coordinator_account,
         },


### PR DESCRIPTION
## Summary

We got this error, might be due to sending a health check from the local user toward a user that's not the local user:

```
2025-09-21T02:33:32.227262Z  INFO psyche_solana_client::backend: Sending transaction: Health check

thread 'tokio-runtime-worker' panicked at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/solana-sdk-2.1.4/src/transaction/mod.rs:734:13:
Transaction::sign failed with error NotEnoughSigners
stack backtrace:
   0:     0x55a9e30d74b2 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::hf435e8e9347709a8
   1:     0x55a9e3105fa3 - core::fmt::write::h0a51fad3804c5e7c
   2:     0x55a9e30d2313 - std::io::Write::write_fmt::h9759e4151bf4a45e
   3:     0x55a9e30d7302 - std::sys::backtrace::BacktraceLock::print::h1ec5ce5bb8ee285e
   4:     0x55a9e30d969c - std::panicking::default_hook::{{closure}}::h5ffefe997a3c75e4
   5:     0x55a9e30d949f - std::panicking::default_hook::h820c77ba0601d6bb
   6:     0x55a9e30da032 - std::panicking::rust_panic_with_hook::h8b29cbe181d50030
   7:     0x55a9e30d9dea - std::panicking::begin_panic_handler::{{closure}}::h9f5b6f6dc6fde83e
   8:     0x55a9e30d79b9 - std::sys::backtrace::__rust_end_short_backtrace::hd7b0c344383b0b61
   9:     0x55a9e30d9a7d - __rustc[5224e6b81cd82a8f]::rust_begin_unwind
  10:     0x55a9e0e01f20 - core::panicking::panic_fmt::hc49fc28484033487
  11:     0x55a9e135d84b - solana_sdk::transaction::Transaction::new::h30f4012a36817826
  12:     0x55a9e1265cef - anchor_client::RequestBuilder<C,S>::signed_transaction_with_blockhash::hecfe9ce2c0552282
  13:     0x55a9e0f1c6ff - psyche_solana_client::backend::SolanaBackend::send_and_retry_with::{{closure}}::hf080e5a111595971
  14:     0x55a9e0ee198a - <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll::h476d24e26ac06e27
  15:     0x55a9e10535fb - tokio::runtime::task::core::Core<T,S>::poll::he31eb47b4085df32
  16:     0x55a9e0f6ecd2 - tokio::runtime::task::harness::Harness<T,S>::poll::hfe5f70608203071b
  17:     0x55a9e2af491c - tokio::runtime::scheduler::multi_thread::worker::Context::run_task::h726217fabf0d02d8
  18:     0x55a9e2af38ef - tokio::runtime::scheduler::multi_thread::worker::Context::run::h43651bd64a0a9645
  19:     0x55a9e2acf958 - tokio::runtime::context::scoped::Scoped<T>::set::hba587c2afc4fdce5
  20:     0x55a9e2acf7f1 - tokio::runtime::context::runtime::enter_runtime::h063b19cf8f94be0e
  21:     0x55a9e2af2f2d - tokio::runtime::scheduler::multi_thread::worker::run::hf6b112f39744c9bf
  22:     0x55a9e2ae5b92 - <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll::h5be026ef7ba0ec7a
  23:     0x55a9e2acb175 - tokio::runtime::task::core::Core<T,S>::poll::he913d29ef07cacae
  24:     0x55a9e2ac3a01 - tokio::runtime::task::harness::Harness<T,S>::poll::h5e74582d3ebc5cb1
  25:     0x55a9e2ac0b87 - tokio::runtime::blocking::pool::Inner::run::h01c8625167112170
  26:     0x55a9e2acbfd0 - std::sys::backtrace::__rust_begin_short_backtrace::h0e9847401c12cc81
  27:     0x55a9e2adacd2 - core::ops::function::FnOnce::call_once{{vtable.shim}}::had8136012c2b2c6f
  28:     0x55a9e30dd90f - std::sys::pal::unix::thread::Thread::new::thread_start::h1ff51d6e85162efd
  29:     0x7f11db38097a - start_thread
  30:     0x7f11db408af4 - __clone
  31:                0x0 - <unknown>
```

## Details

In this case, we just make sure to pass the payer (aka the local user) as the signer in all health checks