### PR TITLE
metrics: use solana pubkey as instance ID

### DIFF
--- a/architectures/decentralized/solana-client/src/main.rs
+++ b/architectures/decentralized/solana-client/src/main.rs
@@ -463,7 +463,7 @@ async fn async_main() -> Result<()> {
                 }))
                 .with_service_info(ServiceInfo {
                     name: "psyche-solana-client".to_string(),
-                    instance_id: identity_secret_key.public().to_string(),
+                    instance_id: wallet_keypair.pubkey().to_string(),
                     namespace: "psyche".to_string(),
                     deployment_environment: std::env::var("DEPLOYMENT_ENV")
                         .unwrap_or("development".to_string()),


### PR DESCRIPTION
in the decentralized client, it's useful to use the solana pubkey to identify nodes.