### PR TITLE
Add run_id to ServiceInfo so that metrics are annotated

### DIFF
--- a/architectures/centralized/client/src/main.rs
+++ b/architectures/centralized/client/src/main.rs
@@ -100,6 +100,7 @@ async fn async_main() -> Result<()> {
                     namespace: "psyche".to_string(),
                     deployment_environment: std::env::var("DEPLOYMENT_ENV")
                         .unwrap_or("development".to_string()),
+                    run_id: args.run_id.clone(),
                 })
                 .init()?;
 

--- a/architectures/centralized/server/src/main.rs
+++ b/architectures/centralized/server/src/main.rs
@@ -195,6 +195,7 @@ async fn main() -> Result<()> {
                     namespace: "psyche".to_string(),
                     deployment_environment: std::env::var("DEPLOYMENT_ENV")
                         .unwrap_or("development".to_string()),
+                    run_id: "".to_string(),
                 })
                 .init()?;
             match config {

--- a/architectures/decentralized/solana-client/src/main.rs
+++ b/architectures/decentralized/solana-client/src/main.rs
@@ -467,6 +467,7 @@ async fn async_main() -> Result<()> {
                     namespace: "psyche".to_string(),
                     deployment_environment: std::env::var("DEPLOYMENT_ENV")
                         .unwrap_or("development".to_string()),
+                    run_id: args.run_id.clone(),
                 })
                 .init()?;
 

--- a/shared/tui/src/logging.rs
+++ b/shared/tui/src/logging.rs
@@ -244,15 +244,17 @@ pub struct ServiceInfo {
     pub instance_id: String,
     pub namespace: String,
     pub deployment_environment: String,
+    pub run_id: String,
 }
 
 impl ServiceInfo {
-    pub fn into_attributes(self) -> [KeyValue; 4] {
+    pub fn into_attributes(self) -> [KeyValue; 5] {
         [
             KeyValue::new("service.name", self.name),
             KeyValue::new("service.instance.id", self.instance_id),
             KeyValue::new("service.namespace", self.namespace),
             KeyValue::new("deployment.environment.name", self.deployment_environment),
+            KeyValue::new("run.id", self.run_id),
         ]
     }
 }

--- a/telemetry/otel-collector-config.yaml
+++ b/telemetry/otel-collector-config.yaml
@@ -17,6 +17,8 @@ exporters:
 
   prometheus:
     endpoint: '0.0.0.0:8889'
+    resource_to_telemetry_conversion:
+      enabled: true
     const_labels:
       service: 'otel-collector'
 


### PR DESCRIPTION
Injects `run_id` into the ServiceInfo struct as that is consumed by the metrics library when pushing to a metrics host.

Annoyingly, we don't always have access to a run_id though, notably in the centralized server. I've left it blank there, but can easily change that up.

There's likely other impact from this change that I haven't forseen, but from what I've poked around it seems to be safe enough.