### PR TITLE
optimize ci integration test

### DIFF
--- a/architectures/decentralized/testing/tests/integration_tests.rs
+++ b/architectures/decentralized/testing/tests/integration_tests.rs
@@ -49,7 +49,7 @@ async fn test_one_clients_three_epochs_run() {
         docker.clone(),
         1,
         Some(PathBuf::from(
-            "../../config/solana-test/nano-one-min-clients.toml",
+            "../../config/solana-test/light-one-min-clients.toml",
         )),
     )
     .await;
@@ -220,7 +220,7 @@ async fn test_client_join_and_get_model_p2p(#[values(1, 2)] n_new_clients: u8) {
         docker.clone(),
         1,
         Some(PathBuf::from(
-            "../../config/solana-test/nano-one-min-clients.toml",
+            "../../config/solana-test/light-one-min-clients.toml",
         )),
     )
     .await;

--- a/config/solana-test/light-one-min-clients.toml
+++ b/config/solana-test/light-one-min-clients.toml
@@ -1,0 +1,45 @@
+[config]
+warmup_time = 50
+cooldown_time = 30
+rounds_per_epoch = 20
+max_round_train_time = 40
+round_witness_time = 1
+min_clients = 1
+init_min_clients = 1
+verification_percent = 0
+witness_nodes = 1
+global_batch_size_start = 4
+global_batch_size_end = 4
+global_batch_size_warmup_tokens = 0
+total_steps = 25000
+
+[model.LLM]
+architecture = "HfLlama"
+data_type = "Pretraining"
+max_seq_len = 64
+cold_start_warmup_steps = 0
+
+[model.LLM.checkpoint.Hub]
+repo_id = "pefontana/Nano-Llama"
+revision = "cf48eac4944f6e954a3d9c9c30e8c865e64e7d03"
+
+[model.LLM.data_location.Http]
+token_size_in_bytes = "TwoBytes"
+shuffle = "DontShuffle"
+
+[model.LLM.data_location.Http.location]
+SingleUrl = "https://huggingface.co/pefontana/Nano-Llama/resolve/main/tiny-ci-dataset/000_tiny-test.ds"
+
+[model.LLM.lr_schedule.Cosine]
+base_lr = 4.0e-4
+warmup_steps = 250
+warmup_init_lr = 0.0
+total_steps = 25000
+final_lr = 4.0e-5
+
+[model.LLM.optimizer.Distro]
+clip_grad_norm = 1.0
+compression_decay = 0.999
+compression_chunk = 64
+compression_topk = 8
+quantize_1bit = true

--- a/python/python/psyche/sidecar/__main__.py
+++ b/python/python/psyche/sidecar/__main__.py
@@ -154,6 +154,9 @@ def main():
         store=store,
     )
 
+    def barrier():
+        dist.barrier(device_ids=[args.device] if args.device is not None else None)
+
     architecture = store.get("architecture").decode()
     source = store.get("source").decode()
     if source == "files":
@@ -165,7 +168,7 @@ def main():
         source = PretrainedSourceRepoFiles(files=expanded_files)
     elif source == "config_and_tensors":
         # Sync all ranks before receiving anything
-        dist.barrier()
+        barrier()
         config = store.get("config").decode()
         tensor_names = json.loads(store.get("tensor_names").decode())
         state_dict = {}
@@ -189,10 +192,8 @@ def main():
             # Create empty tensor to overwrite with the broadcasted tensor
             tensor = torch.empty(tensor_shape, dtype=tensor_dtype, device=args.device)
 
-            print("Received tensor:", name)
             dist.broadcast(tensor, 0)
-            dist.barrier()
-            print("Continue")
+            barrier()
 
             state_dict[name] = tensor
 
@@ -224,9 +225,7 @@ def main():
             return
         operation = json.loads(operation.decode())
 
-        # dummy barrier
-        dummy = torch.zeros((), dtype=torch.float, device=device)
-        dist.all_reduce(dummy)
+        barrier()
 
         if operation["operation"] == "hyperparameters":
             hyperparameters: Hyperparameters = Hyperparameters(**operation)


### PR DESCRIPTION
Make optimization to Solana integration test workflows, to reduce execution time and memory usage:
* Cache docker-psyche-solana-test-validator image: We just build it ones and save it, then, all the other workflows donwload it. Also, we save it for later workflows and only recompile it when there are changes in the solana-coordinator and solana-authorizer code
* Compile `psyche-solana-test-client-no-python`  in Garnix: Now we campile the `docker-psyche-solana-test-client-no-python` in Garnix and the test workflows downloaded from there