### PR TITLE
Disable liger kernel in Mac OS

### DIFF
--- a/python/default.nix
+++ b/python/default.nix
@@ -75,8 +75,10 @@ python312Packages.buildPythonPackage rec {
     [
       torch
       transformers
-      (python312Packages.callPackage ./liger-kernel.nix { })
     ]
+    ++ (lib.optionals (!stdenv.isDarwin) [
+      (python312Packages.callPackage ./liger-kernel.nix { })
+    ])
     ++ (lib.optionals config.cudaSupport [
       (python312Packages.callPackage ./flash-attn.nix { })
     ]);


### PR DESCRIPTION
Liger kernel package does not support aarch64-darwin