### PR TITLE
test actions dependency with garnix

### DIFF
--- a/.github/actions/wait-for-garnix/action.yaml
+++ b/.github/actions/wait-for-garnix/action.yaml
@@ -1,0 +1,50 @@
+name: 'Wait for Garnix CI'
+description: 'Wait for Garnix CI checks to complete'
+inputs:
+  timeout-minutes:
+    description: 'Maximum time to wait in minutes'
+    required: false
+    default: '10'
+runs:
+  using: 'composite'
+  steps:
+    - name: Wait for All Garnix checks
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+        echo "Waiting for 'All Garnix checks' on commit $SHA"
+        TOTAL_ATTEMPTS=$(( ${{ inputs.timeout-minutes }} * 2 ))
+
+        for i in $(seq 1 $TOTAL_ATTEMPTS); do
+          CHECK=$(gh api repos/${{ github.repository }}/commits/$SHA/check-runs --jq '.check_runs[] | select(.name == "package docker-psyche-solana-test-client-no-python [x86_64-linux]") | {name: .name, status: .status, conclusion: .conclusion}')
+          if [ -z "$CHECK" ]; then
+            echo "No 'package docker-psyche-solana-test-client-no-python [x86_64-linux]' found yet, waiting..."
+            sleep 10
+            continue
+          fi
+
+          STATUS=$(echo "$CHECK" | jq -r '.status')
+          CONCLUSION=$(echo "$CHECK" | jq -r '.conclusion')
+
+          if [ "$CONCLUSION" = "null" ]; then
+            echo "Garnix check for image generation: $STATUS (conclusion: pending)"
+          fi
+
+          if [ "$STATUS" = "completed" ]; then
+            if [ "$CONCLUSION" = "success" ]; then
+              echo "Image generation job in Garnix passed!"
+              exit 0
+            else
+              echo "Image generation job in Garnix failed with conclusion: $CONCLUSION"
+              exit 1
+            fi
+          fi
+
+          echo "Waiting for 'package docker-psyche-solana-test-client-no-python [x86_64-linux]' to complete... (attempt $i/$TOTAL_ATTEMPTS)"
+          sleep 10
+
+        done
+        echo "Timeout waiting for 'All Garnix checks'"
+        exit 1

--- a/.github/workflows/solana-integration-test-base.yml
+++ b/.github/workflows/solana-integration-test-base.yml
@@ -15,6 +15,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
 
@@ -24,10 +28,6 @@ jobs:
           df -h
           echo "Docker info"
           docker info | grep -i "docker root dir" || true
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       - uses: nixbuild/nix-quick-install-action@v31
         with:
@@ -68,6 +68,11 @@ jobs:
           df -h
 
       # Step 2: Download Solana Test Client No Python Image
+
+      # Wait for Garnix right before downloading from Garnix cache
+      - name: Wait for Garnix checks
+        uses: ./.github/actions/wait-for-garnix
+
       - name: Download Solana Test Client No Python Image
         run: |
           echo "Disk space before client build"

--- a/.github/workflows/solana-integration-test-run.yml
+++ b/.github/workflows/solana-integration-test-run.yml
@@ -1,11 +1,9 @@
 name: Solana integration tests run
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main, '**']
-
 jobs:
   # First, build the validator image and cache it
   build-validator:


### PR DESCRIPTION
This PR adds a custom action to the CI that checks for the Garnix job that builds the docker image used for tests to be completed before running the integration tests, this way we avoids any race conditions that could make the tests not finding the correct generated image in the Garnix job