### PR TITLE
Fix early epoch end bug

### DIFF
--- a/shared/coordinator/src/coordinator.rs
+++ b/shared/coordinator/src/coordinator.rs
@@ -992,7 +992,7 @@ impl<T: NodeIdentity> Coordinator<T> {
             if height == self.config.rounds_per_epoch - 1
                 || self.epoch_state.clients.len() < self.config.min_clients as usize
                 || num_witnesses < self.witness_quorum(num_witnesses)
-                || self.progress.step > self.config.total_steps
+                || self.progress.step >= self.config.total_steps
                 || self.pending_pause.is_true()
             {
                 self.start_cooldown(unix_timestamp);


### PR DESCRIPTION
This PR makes a simple fix to the coordinator so that the end of epoch check at line 992 includes an additional check for the total steps. This allows it to start the cooldown and enter a finished state when a lower total step count is hit prior to the rounded epoch step count.

I have included a test at the end of the file to assert this (somewhat based off the test in data_selection.rs).