### PR TITLE
When a training round exceeds total_steps, transition to witness state

### DIFF
--- a/shared/coordinator/src/coordinator.rs
+++ b/shared/coordinator/src/coordinator.rs
@@ -959,6 +959,9 @@ impl<T: NodeIdentity> Coordinator<T> {
         if self.check_timeout(unix_timestamp, self.config.max_round_train_time) {
             self.change_state(unix_timestamp, RunState::RoundWitness);
         }
+        if self.progress.step > self.config.total_steps {
+            self.change_state(unix_timestamp, RunState::RoundWitness);
+        }
         Ok(TickResult::Ticked)
     }
 


### PR DESCRIPTION
By stepping to the next state in the state machine upon exceeding total_steps, the process will evaluate the state of the run and determine that it should complete the epoch and overall run.

This should resolve https://github.com/PsycheFoundation/psyche/issues/379