### PR TITLE
Change the way our local metrics harness is configured to match Grafana Cloud

### DIFF
--- a/telemetry/docker-compose.yml
+++ b/telemetry/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-otlp-receiver'
 
   loki:
     image: grafana/loki:latest

--- a/telemetry/otel-collector-config.yaml
+++ b/telemetry/otel-collector-config.yaml
@@ -15,12 +15,8 @@ exporters:
   loki:
     endpoint: http://loki:3100/loki/api/v1/push
 
-  prometheus:
-    endpoint: '0.0.0.0:8889'
-    resource_to_telemetry_conversion:
-      enabled: true
-    const_labels:
-      service: 'otel-collector'
+  otlphttp:
+    endpoint: http://prometheus:9090/api/v1/otlp/v1/metrics
 
   # Useful for debugging to see logs in the collector's stdout
   debug:
@@ -41,4 +37,4 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [prometheus, debug]
+      exporters: [otlphttp, debug]

--- a/telemetry/prometheus.yml
+++ b/telemetry/prometheus.yml
@@ -12,3 +12,6 @@ scrape_configs:
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
+
+otlp:
+  keep_identifying_resource_attributes: true


### PR DESCRIPTION
The way we had things configured caused a slight mismatch in the way metrics were processed vs Grafana Cloud. This change should move us closer to the way they process metrics.

Specifically this will cause a separate metric timeseries `target_info` to be generated, which has annotations with the `run_id` along with other useful data.

With this change in place, we can utilize unmodified clones of the dashboard on Grafana Cloud locally, which should allow us to create a CD pipeline for them.