### PR TITLE
Update consilience-match-llama2-20m-fineweb to fit in 32 char run_id limit

### DIFF
--- a/config/consilience-match-llama2-20m-fineweb-pretrain-dev/state.toml
+++ b/config/consilience-match-llama2-20m-fineweb-pretrain-dev/state.toml
@@ -1,4 +1,4 @@
-run_id = "consilience-match-llama2-20m-fineweb"
+run_id = "consilience-match-llama2-20m-fin"
 run_state = "WaitingForMembers"
 [config]
 warmup_time = 30


### PR DESCRIPTION
Before this you get a semi silent failure that you have to dig through the logs for as the server process reads the state and auto truncates to 32 chars, but the clients do not auto-truncate, leading to the clients never successfully joining a run.

Obviously, we should fix the underlying issue here, but this quick fix at least unblocks local dev.