### PR TITLE
Fixing Python dev shell by removing Jax dependency

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -22,6 +22,16 @@ in
             liger-kernel = pyfinal.callPackage ../python/liger-kernel.nix { };
             torchtitan = pyfinal.callPackage ../python/torchtitan.nix { };
             torchdata = pyfinal.callPackage ../python/torchdata.nix { };
+            tyro = pyprev.tyro.overridePythonAttrs (old: {
+              propagatedBuildInputs = builtins.filter (
+                dep:
+                !builtins.elem (dep.pname or "") [
+                  "jax"
+                  "jaxlib"
+                ]
+              ) (old.propagatedBuildInputs or [ ]);
+              doCheck = false;
+            });
           };
         };
       })

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,6 +11,8 @@ override-dependencies = [
   "torchtitan; sys_platform == 'never'",
   "flash-attn; sys_platform == 'never'",
   "liger-kernel; sys_platform == 'never'",
+  "jax; sys_platform == 'never'",
+  "jaxlib; sys_platform == 'never'",
 ]
 
 [project.optional-dependencies]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -5,6 +5,8 @@ requires-python = "==3.12.*"
 [manifest]
 overrides = [
     { name = "flash-attn", marker = "sys_platform == 'never'" },
+    { name = "jax", marker = "sys_platform == 'never'" },
+    { name = "jaxlib", marker = "sys_platform == 'never'" },
     { name = "liger-kernel", marker = "sys_platform == 'never'" },
     { name = "torch", marker = "sys_platform == 'never'" },
     { name = "torchtitan", marker = "sys_platform == 'never'" },


### PR DESCRIPTION
I've narrowed down the inclusion of `python3.12-jax-0.8.0` to be from `transformers -> tyro`, in which `jax` is an optional dependency used for type annotations (which we don't need). 

This PR removes it and successfully builds the Python devshell.