### PR TITLE
Increase the FixedVec size of WitnessEvalResult

### DIFF
--- a/shared/client/src/state/stats.rs
+++ b/shared/client/src/state/stats.rs
@@ -175,7 +175,7 @@ impl StatsLogger {
         let bandwidth_total: f64 = self.endpoint_info.iter().map(|v| v.bandwidth).sum();
 
         let evals = {
-            let mut evals: FixedVec<WitnessEvalResult, 8> = Default::default();
+            let mut evals: FixedVec<WitnessEvalResult, 10> = Default::default();
             for (key, val) in self.current_eval_results() {
                 let value = WitnessEvalResult::new_trunc_name(&key, no_nan(val as f32, 0.0));
                 if evals.push(value).is_err() {

--- a/shared/coordinator/src/coordinator.rs
+++ b/shared/coordinator/src/coordinator.rs
@@ -175,7 +175,7 @@ pub struct WitnessMetadata {
     pub tokens_per_sec: f32,
     pub bandwidth_per_sec: f32,
     pub loss: f32,
-    pub evals: FixedVec<WitnessEvalResult, 8>,
+    pub evals: FixedVec<WitnessEvalResult, 10>,
     pub prompt_results: FixedVec<i32, { MAX_TOKENS_TO_SEND }>,
     pub prompt_index: u8,
     pub efficency: f32,


### PR DESCRIPTION
Increase the FixedVec size of WitnessEvalResult, so a client is able to send all the eval results in the WitnessMetadata