### PR TITLE
Fix command to download image from Garnix cache

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Download image from Garnix cache
         run: |
-          nix build --max-jobs 0 .#docker-psyche-solana-client --no-link --print-out-paths > image-path.txt
+          nix .#docker-psyche-solana-client --no-link --print-out-paths > image-path.txt
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
this is more of a hack than a fix. I'm unhappy with our CI situation. 