### PR TITLE
chore: remove dead code from main function

### DIFF
--- a/architectures/centralized/client/src/main.rs
+++ b/architectures/centralized/client/src/main.rs
@@ -5,9 +5,9 @@ use clap::{Parser, Subcommand};
 use psyche_client::{TrainArgs, print_identity_keys, read_identity_secret_key};
 use psyche_network::SecretKey;
 use psyche_tui::{
+    LogOutput, ServiceInfo,
     logging::{MetricsDestination, OpenTelemetry, RemoteLogsDestination, TraceDestination},
     maybe_start_render_loop,
-    LogOutput, ServiceInfo,
 };
 use std::{path::PathBuf, time::Duration};
 use time::OffsetDateTime;


### PR DESCRIPTION
### Description
Removes commented-out dead code from the main() function in the centralized client.
### Changes
- Removed commented shutdown_handler variable declaration and shutdown call from main()
- Logger shutdown is already handled in async_main() via logger.shutdown(), making the commented code redundant