### PR TITLE
add sft data preprocessing script

### DIFF
--- a/scripts/preprocess-finetuning-data.py
+++ b/scripts/preprocess-finetuning-data.py
@@ -929,7 +929,7 @@ def main(args):
             label = labels[i] if labels is not None else token
             position_id = position_ids[i] if position_ids is not None else None
 
-            decoded = tokenizer.decode(token)
+            decoded = tokenizer.decode([token])
 
             if label == -100:
                 example_out += f"\033[31m{decoded}\033[0m({token}"


### PR DESCRIPTION
adds the sft preprocessing script to the repo. it canonically resides at https://github.com/NousResearch/torchtitan/blob/dev-updated-again/scripts/preprocess_data.py but seemed worthwhile to have a copy here so you don't need to clone torchtitan as part of the model creation workflow