### PR TITLE
Reduces GPU memory usage during log-likelihood evaluations

### DIFF
--- a/shared/eval/src/harness.rs
+++ b/shared/eval/src/harness.rs
@@ -849,14 +849,7 @@ fn calculate_unconditional_loglikelihood(
 
     let (logits_uncond, _) = {
         let _no_grad = tch::no_grad_guard();
-        model.forward(
-            &uncond_tensor,
-            None,
-            None,
-            None,
-            Some(uncond_request.len() as i64),
-            None,
-        )
+        model.forward(&uncond_tensor, None, None, None, None, None)
     };
 
     let logits_uncond = logits_uncond.unwrap().squeeze_dim(0);


### PR DESCRIPTION
Reduces GPU memory usage during log-likelihood evaluations by only computing logits for the tokens we actually need to score, instead of computing logits for the entire sequence and then slicing.

The result of the evaluation are still de same:

```
# [deepseek-ai/DeepSeek-V2-Lite](https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite)
## main
Vram usage: main  36.030GB
  - ARC-Easy: 0 few-shot examples
ARC-Easy: {"acc_uncond": 0.6994949494949495, "acc": 0.7668350168350169, "acc_norm": 0.7323232323232324}

## evals-optimization
Vram usage: main  36.008GB
  - ARC-Easy: 0 few-shot examples
ARC-Easy: {"acc_uncond": 0.6994949494949495, "acc": 0.7668350168350169, "acc_norm": 0.7323232323232324}



# [TinyLlama-1.1B-Chat-v0.4](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v0.4)
## main
Vram usage: main  3.192GB
  - ARC-Easy: 0 few-shot examples
ARC-Easy: {"acc_norm": 0.5244107744107744, "acc": 0.5698653198653199, "acc_uncond": 0.4970538720538721}

## evals-optimization
Vram usage: main  3.172GB

- ARC-Easy: 0 few-shot examples
ARC-Easy: {"acc_norm": 0.5248316498316499, "acc_uncond": 0.4957912457912458, "acc": 0.5686026936026936}
```

