### PR TITLE
Revert "Reduces GPU memory usage during log-likelihood evaluations"

### DIFF
--- a/shared/eval/src/harness.rs
+++ b/shared/eval/src/harness.rs
@@ -493,24 +493,29 @@ impl PreparedTask {
 
                 // The request already contains [fewshot_tokens] + [question + choice_without_last_token]
                 let full_request = request;
+                let input_length = &full_request.len();
 
                 let request_tensor = Tensor::from_slice(&full_request)
                     .to(options.model.device())
                     .unsqueeze(0);
                 let (logits, _) = {
                     let _no_grad = tch::no_grad_guard();
-                    options.model.forward(
-                        &request_tensor,
-                        None,
-                        None,
-                        None,
-                        Some(choice.len() as i64),
-                        None,
-                    )
+                    options
+                        .model
+                        .forward(&request_tensor, None, None, None, None, None)
                 };
 
-                // Shape: [choice.len(), vocab_size]
-                let logits = logits.unwrap().squeeze_dim(0);
+                let logits = logits.unwrap().squeeze_dim(0).slice(0, 0, None, 1);
+
+                // Get tensor of shape `[choice.len(), vocab_size]` containing the
+                // model's logits for each token of the `choice` text.
+                // This should skip the fewshot tokens and get the tokens from the end.
+                let logits = logits.slice(
+                    0,
+                    *input_length as i64 - choice.len() as i64,
+                    *input_length as i64,
+                    1,
+                );
 
                 let greedy_tokens: Vec<i64> = logits.argmax(-1, false).try_into().unwrap();
                 let exact_match = greedy_tokens.eq(&choice);


### PR DESCRIPTION
Reverts PsycheFoundation/psyche#515

Live run crashed when doing evals

```
thread 'tokio-runtime-worker' (142) panicked at shared/eval/src/harness.rs:515:83:
called `Result::unwrap()` on an `Err` value: Convert("Attempting to convert a Tensor with 0 dimensions to flat vector")
stack backtrace:
   0:     0x557dddc536f2 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h4e0a3aeea0f9c085
   1:     0x557dddc682ff - core::fmt::write::hecf68a131630c74d
   2:     0x557dddc190e1 - std::io::Write::write_fmt::h93c9a261259c931a
   3:     0x557dddc28b52 - std::sys::backtrace::BacktraceLock::print::h75160192768e5621
   4:     0x557dddc2ec9f - std::panicking::default_hook::{{closure}}::h14d82797cfb1ddcb
   5:     0x557dddc2eaf9 - std::panicking::default_hook::h63f9bf8161c5d325
   6:     0x557dddc2f3d5 - std::panicking::panic_with_hook::h3173740e06bd0752
   7:     0x557dddc2f1ba - std::panicking::panic_handler::{{closure}}::hbac492c61eb56a87
   8:     0x557dddc28c99 - std::sys::backtrace::__rust_end_short_backtrace::haa3eac3df9535320
   9:     0x557dddc0bf2d - __rustc[de0091b922c53d7e]::rust_begin_unwind
  10:     0x557dddc736b0 - core::panicking::panic_fmt::h5138da2ef87be35b
  11:     0x557dddc72676 - core::result::unwrap_failed::h5d9b16b0b732a2ac
  12:     0x557ddc017a81 - psyche_eval::harness::PreparedTask::run_log_likelihood::h7a01ae804ce6a5b9
  13:     0x557ddc018c49 - psyche_eval::harness::PreparedTask::run::h6777534df8e7c1b7
  14:     0x557ddbfc263f - psyche_client::state::evals::EvalTask::run::h9d5cf8e0a1679ba4
  15:     0x557ddbfefa7f - <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll::h8defd29ecaed7811
  16:     0x557ddbfcc6b7 - tokio::runtime::task::core::Core<T,S>::poll::hfec3d5240f6b1e7d
  17:     0x557ddbfece46 - tokio::runtime::task::harness::Harness<T,S>::poll::h92dab85b34973388
  18:     0x557ddd63d6a4 - tokio::runtime::blocking::pool::Inner::run::h7491d3e62fb74cb6
  19:     0x557ddd61a70a - std::sys::backtrace::__rust_begin_short_backtrace::h6ebe7ea093f08f4e
  20:     0x557ddd61e782 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h313ffd2feec58c14
  21:     0x557dddc23faf - std::sys::thread::unix::Thread::new::thread_start::h38da0f633f090ce2
  22:     0x7fab7b2f597a - start_thread
  23:     0x7fab7b37dd2c - __GI___clone3
  24:                0x0 - <unknown>
```