### PR TITLE
Fix model sharing with `torchtitan`

### DIFF
--- a/python/python/psyche/models/ttitan.py
+++ b/python/python/psyche/models/ttitan.py
@@ -255,7 +255,9 @@ class TorchtitanAuto(CausalLM):
             for k in model_sd.keys()
         }
 
-        for k, source in state_dict.items():
+        sorted_keys = sorted(state_dict.keys())
+        for idx, k in enumerate(sorted_keys):
+            source = state_dict[k]
             actual_key = clean_to_actual.get(k)
             if actual_key is not None:
                 dest = model_sd[actual_key]


### PR DESCRIPTION
This PR fixes the model sharing process when using Torchtitan arch. This was done sorting the names of the model parameter for every rank to process the same model at the same time, which is needed for distribution to work using pytorch distributed package