### PR TITLE
ci: fix push docker image action

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -30,14 +30,11 @@ jobs:
 
       - name: Download image from Garnix cache
         run: |
-          nix build .#docker-psyche-solana-client --no-link --print-out-paths > image-path.txt
+          nix build .#docker-psyche-solana-client --no-link --print-out-paths --max-jobs 0 > image-path.txt
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKER_DEPLOY_KEY }}
-
-      - run: scripts/push-client-image.sh
+      - name: Push image to Docker Hub
+        run: scripts/push-client-image.sh
         env:
           DOCKER_REPOSITORY: ${{ vars.DOCKERHUB_REPO }}
+          REGISTRY_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKER_DEPLOY_KEY }}


### PR DESCRIPTION
Use Skopeo in the script that pushes the docker image to the registry in the CI. This way we stream all the image directly to docker hub instead of saving it to disk in the Github runner