### PR TITLE
CI Solana integration tests more robust.

### DIFF
--- a/architectures/decentralized/testing/tests/integration_tests.rs
+++ b/architectures/decentralized/testing/tests/integration_tests.rs
@@ -398,6 +398,14 @@ async fn disconnect_client() {
                     );
                 }
 
+                if killed_client
+                    && epoch > 0
+                    && new_state == RunState::WaitingForMembers.to_string()
+                {
+                    println!("Epoch ended after killing client, breaking to verify assertions");
+                    break;
+                }
+
                 if epoch == 0
                     && step == 10
                     && old_state == RunState::RoundTrain.to_string()
@@ -742,7 +750,7 @@ async fn test_solana_subscriptions() {
 
                         }
                         // resume subscription 2
-                        if step == 45 && new_state == RunState::RoundWitness.to_string(){
+                        if step == 30 && new_state == RunState::RoundWitness.to_string(){
                             println!("resume container {NGINX_PROXY_PREFIX}-2");
 
                             docker


### PR DESCRIPTION
We observed that `test_solana_subscriptions` and `disconnect_client` occasionally fail on slow CI machines due to timing issues.
This change reduces proxy downtime and adds early exit conditions to make the tests more robust.