### PR TITLE
chore: update Cargo.lock for authorizer and coordinator

### DIFF
--- a/architectures/decentralized/solana-authorizer/Cargo.lock
+++ b/architectures/decentralized/solana-authorizer/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "psyche-solana-authorizer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/architectures/decentralized/solana-coordinator/Cargo.lock
+++ b/architectures/decentralized/solana-coordinator/Cargo.lock
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "psyche-coordinator"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anchor-lang",
  "async-trait",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "psyche-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anchor-lang",
  "anchor-lang-idl",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "psyche-solana-authorizer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "psyche-solana-coordinator"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anchor-lang",
  "bytemuck",


### PR DESCRIPTION
version has changed to 0.2.0 on both but the .lock files were never updated