### PR TITLE
mute lint warns when running run-manager via cargo

### DIFF
--- a/architectures/decentralized/solana-authorizer/programs/solana-authorizer/Cargo.toml
+++ b/architectures/decentralized/solana-authorizer/programs/solana-authorizer/Cargo.toml
@@ -17,6 +17,12 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = [
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("custom-heap", "custom-panic"))',
+] }
+
 [dependencies]
 anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5" }
 anchor-spl = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5" }

--- a/architectures/decentralized/solana-coordinator/programs/solana-coordinator/Cargo.toml
+++ b/architectures/decentralized/solana-coordinator/programs/solana-coordinator/Cargo.toml
@@ -17,6 +17,12 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = [
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("custom-heap", "custom-panic"))',
+] }
+
 [dependencies]
 anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5" }
 bytemuck = { version = "1", features = [

--- a/architectures/decentralized/solana-mining-pool/programs/solana-mining-pool/Cargo.toml
+++ b/architectures/decentralized/solana-mining-pool/programs/solana-mining-pool/Cargo.toml
@@ -17,6 +17,12 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 anchor-debug = []
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = [
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("custom-heap", "custom-panic"))',
+] }
+
 [dependencies]
 anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5" }
 anchor-spl = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5" }

--- a/architectures/decentralized/solana-treasurer/programs/solana-treasurer/Cargo.toml
+++ b/architectures/decentralized/solana-treasurer/programs/solana-treasurer/Cargo.toml
@@ -17,6 +17,12 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 anchor-debug = []
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = [
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("custom-heap", "custom-panic"))',
+] }
+
 [dependencies]
 anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5" }
 anchor-spl = { git = "https://github.com/coral-xyz/anchor.git", rev = "a7a23eea308440a9fa9cb79cee7bddd30ab163d5" }


### PR DESCRIPTION
When running/compiling run-manager via cargo we see a lot of annoying warnings of the type

```
warning: unexpected `cfg` condition value: `custom-heap`
  --> architectures/decentralized/solana-treasurer/programs/solana-treasurer/src/lib.rs:29:1
   |
29 | #[program]
   | ^^^^^^^^^^
   |
   = note: expected values for `feature` are: `anchor-debug`, `cpi`, `default`, `idl-build`, `no-entrypoint`, `no-idl`, and `no-log-ix-name`
   = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
   = help: try referring to `$crate::custom_heap_default` crate for guidance on how handle this unexpected cfg
   = help: the macro `$crate::custom_heap_default` may come from an old version of the `solana_program_entrypoint` crate, try updating your dependency with `cargo update -p solana_program_entrypoint`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default
   = note: this warning originates in the macro `$crate::custom_heap_default` which comes from the expansion of the attribute macro `program` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `solana`
  --> architectures/decentralized/solana-treasurer/programs/solana-treasurer/src/lib.rs:29:1
   |
29 | #[program]
   | ^^^^^^^^^^
   |
   = note: expected values for `target_os` are: `aix`, `amdhsa`, `android`, `cuda`, `cygwin`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `helenos`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `lynxos178`, `macos`, `managarm`, `motor`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `qurt`, `redox`, `rtems`, `solaris`, and `solid_asp3` and 14 more
   = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
   = help: try referring to `$crate::custom_heap_default` crate for guidance on how handle this unexpected cfg
   = help: the macro `$crate::custom_heap_default` may come from an old version of the `solana_program_entrypoint` crate, try updating your dependency with `cargo update -p solana_program_entrypoint`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: this warning originates in the macro `$crate::custom_heap_default` which comes from the expansion of the attribute macro `program` (in Nightly builds, run with -Z macro-backtrace for more info)
```

afaik this is an Anchor thing and we can just ignore them
