### PR TITLE
Fix #522: Catch authorization errors and prevent auto-rejoining

### DIFF
--- a/architectures/decentralized/solana-common/src/backend.rs
+++ b/architectures/decentralized/solana-common/src/backend.rs
@@ -558,6 +558,12 @@ impl SolanaBackend {
                         return Ok(signature);
                     }
                     Err(error) => {
+                        if error.to_string().contains("authorization") && error.to_string().contains("AccountNotInitialized") {
+                            return Err(anyhow!(
+                                "Error: Account not been initialized. You are unable to join this run\n\
+                                Error message: {error}"
+                            ));
+                        }
                         retries += 1;
                         if retries >= SEND_RETRIES {
                             return Err(anyhow!(

--- a/docker/train_entrypoint.sh
+++ b/docker/train_entrypoint.sh
@@ -96,6 +96,12 @@ while true; do
         exit 10
     fi
 
+    # Exit code 11 means authorization error - exit container immediately (no retry)
+    if [[ $EXIT_STATUS -eq 11 ]]; then
+        echo -e "[!] Uninitialized account detected. Exiting container without retry..."
+        exit 11
+    fi
+
     # Reset restart counter if client ran longer than RESET_TIME
     if [ $duration -ge $RESET_TIME ]; then
         num_restarts=0


### PR DESCRIPTION
When users try to join a run without an authorized account, the client throws a cryptic error and will problematically continue to auto-rejoin. This pull request catches the "AccountNotInitialized" authorization errors and now throws a cleaner error, then exits Psyche. The docker wrapper no longer auto-rejoins when such errors occur.

Specific File Changes:
- backend.rs: Detect AccountNotInitialized authorization errors, throwing cleaner error
- app.rs: Exit with exit code 11 when said authorization error occurs
- train_entrypoint.sh: Skip auto-rejoining at exit code 11