### PR TITLE
refactor(client): remove redundant clone of `run_id` in format macro

### DIFF
--- a/architectures/centralized/client/src/app.rs
+++ b/architectures/centralized/client/src/app.rs
@@ -115,7 +115,7 @@ pub async fn build_app(
     let checkpoint_config = p.checkpoint_config()?;
     let wandb_info = p.wandb_info(format!(
         "{}-{}",
-        p.run_id.clone(),
+        p.run_id,
         identity_secret_key.public().fmt_short()
     ))?;
 


### PR DESCRIPTION
The format! macro in Rust works with references, so calling `.clone()` on `p.run_id` (a String) was forcing an unnecessary heap allocation and memory copy right before formatting, only to immediately drop it.
Removed the useless `.clone()` call from `p.run_id` when generating wandb_info in the centralized client (app.rs). This eliminates the redundant memory allocation and aligns the code with idiomatic Rust.