### PR TITLE
Outputting endpoint address JSON to console if no file is written

### DIFF
--- a/architectures/inference-only/inference-node/src/bin/gateway-node.rs
+++ b/architectures/inference-only/inference-node/src/bin/gateway-node.rs
@@ -331,14 +331,20 @@ async fn run_gateway() -> Result<()> {
         args.write_endpoint_file.clone()
     };
 
+    let endpoint_addr = network.router().endpoint().addr();
+    let endpoints = vec![endpoint_addr];
+
     if let Some(ref endpoint_file) = endpoint_file {
-        let endpoint_addr = network.router().endpoint().addr();
-        let endpoints = vec![endpoint_addr];
         let content =
             serde_json::to_string(&endpoints).context("Failed to serialize endpoint address")?;
         fs::write(endpoint_file, content).context("Failed to write endpoint file")?;
         info!("Wrote gateway endpoint to {:?}", endpoint_file);
         info!("Other nodes can bootstrap using this file");
+    } else {
+        let endpoint_json = serde_json::to_string_pretty(&endpoints)
+            .context("Failed to serialize endpoint address")?;
+        info!("Gateway endpoint address (use for bootstrapping inference nodes):");
+        println!("\n{}\n", endpoint_json);
     }
 
     info!("Waiting for gossip mesh to stabilize...");


### PR DESCRIPTION
This PR just prints out the endpoint address used for bootstrapping as a string so we can bootstrap inference nodes for testing.

## Testing
`just gateway-node`

## Output
```
just gateway-node

RUST_LOG=info,psyche_network=debug nix run .#bin-psyche-inference-node-gateway-node -- --discovery-mode n0 --relay-kind n0
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
2026-02-25T00:13:41.083192Z  INFO gateway_node: Starting gateway node
2026-02-25T00:13:41.083211Z  INFO gateway_node:   HTTP API: http://127.0.0.1:8000
2026-02-25T00:13:41.083214Z  INFO gateway_node:   Discovery mode: N0
2026-02-25T00:13:41.083218Z  INFO gateway_node:   Relay kind: N0
2026-02-25T00:13:41.083222Z  INFO psyche_inference_node: No bootstrap peers configured (gateway will be a bootstrap node)
2026-02-25T00:13:41.083234Z  INFO gateway_node: Initializing P2P network...
2026-02-25T00:13:41.553276Z DEBUG psyche_network: Using relay servers: Default iroh relay (production) servers

2026-02-25T00:13:44.616862Z  INFO relay-actor: iroh::socket::transports::relay::actor: home is now relay https://use1-1.relay.n0.iroh-canary.iroh.link./, was None
2026-02-25T00:13:44.616904Z  INFO psyche_network: Our endpoint ID: *endpoint-id*
2026-02-25T00:13:44.616934Z  INFO psyche_network: Iroh metrics not enabled: N0DES_API_SECRET environment variable is not set
2026-02-25T00:13:44.617112Z  INFO psyche_network: Connected!
2026-02-25T00:13:44.617123Z  INFO gateway_node: P2P network initialized
2026-02-25T00:13:44.617126Z  INFO gateway_node:   Endpoint ID: *endpoint-id*
2026-02-25T00:13:44.617129Z  INFO gateway_node: No PSYCHE_GATEWAY_ENDPOINT_FILE env var, checking CLI args
2026-02-25T00:13:44.617146Z  INFO gateway_node: Gateway endpoint address (use for bootstrapping inference nodes):

[{"id":"*endpoint-id*","addrs":[{"Relay":"<relay-server>"},{"Ip":"10.1.10.21:32929"},{"Ip":"10.1.11.21:32929"},{"Ip":"10.1.12.21:32929"},{"Ip":"10.1.13.21:32929"},{"Ip":"10.1.14.21:32929"},{"Ip":"10.1.15.21:32929"},{"Ip":"10.1.16.21:32929"},{"Ip":"10.1.17.21:32929"},{"Ip":"10.2.1.21:32929"},{"Ip":"172.16.0.1:32929"},{"Ip":"172.17.0.1:32929"},{"Ip":"172.18.0.1:32929"},{"Ip":"**************"}]}]

2026-02-25T00:13:44.617153Z  INFO gateway_node: Waiting for gossip mesh to stabilize...
2026-02-25T00:13:49.618530Z  INFO gateway_node: Gossip mesh should be ready
2026-02-25T00:13:49.618557Z  INFO gateway_node: Gateway ready! Listening on http://127.0.0.1:8000
2026-02-25T00:13:49.618561Z  INFO gateway_node: Discovering inference nodes...
2026-02-25T00:13:49.618618Z  INFO gateway_node: HTTP server listening on 127.0.0.1:8000
```