### PR TITLE
Add iroh network diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4644,40 +4644,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-n0des"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff0b9c6bdfd5dcd633c198f9170f2bb4d7f95d1e6ce90b3c40ea363f5a31591"
-dependencies = [
- "anyhow",
- "built",
- "bytes",
- "derive_more",
- "ed25519-dalek 3.0.0-pre.1",
- "futures-buffered",
- "getrandom 0.3.4",
- "iroh",
- "iroh-metrics 0.38.2",
- "iroh-tickets",
- "irpc",
- "irpc-iroh",
- "n0-error",
- "n0-future",
- "portmapper",
- "postcard",
- "rand 0.9.2",
- "rcan",
- "serde",
- "serde_json",
- "strum 0.27.2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
 name = "iroh-quinn"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4783,6 +4749,40 @@ dependencies = [
  "webpki-roots 1.0.6",
  "ws_stream_wasm",
  "z32",
+]
+
+[[package]]
+name = "iroh-services"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e90cec7e16813b8b29eba1d955cccc2505e29c34ceed76722d3857bf2c9072"
+dependencies = [
+ "anyhow",
+ "built",
+ "bytes",
+ "derive_more",
+ "ed25519-dalek 3.0.0-pre.1",
+ "futures-buffered",
+ "getrandom 0.3.4",
+ "iroh",
+ "iroh-metrics 0.38.2",
+ "iroh-tickets",
+ "irpc",
+ "irpc-iroh",
+ "n0-error",
+ "n0-future",
+ "portmapper",
+ "postcard",
+ "rand 0.9.2",
+ "rcan",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -7428,8 +7428,8 @@ dependencies = [
  "iroh",
  "iroh-blobs",
  "iroh-gossip",
- "iroh-n0des",
  "iroh-relay",
+ "iroh-services",
  "n0-future",
  "postcard",
  "psyche-core",

--- a/shared/network/Cargo.toml
+++ b/shared/network/Cargo.toml
@@ -34,7 +34,10 @@ tokenizers.workspace = true
 get_if_addrs = "0.5.3"
 n0-future = "0.3.2"
 url = { version = "2.5", features = ["serde"] }
-iroh-n0des = { version = "0.10", features = ["client_host", "net_diagnostics"] }
+iroh-services = { version = "0.11", features = [
+  "client_host",
+  "net_diagnostics",
+] }
 
 [dev-dependencies]
 # for examples

--- a/shared/network/src/lib.rs
+++ b/shared/network/src/lib.rs
@@ -17,7 +17,7 @@ use iroh_gossip::{
     net::Gossip,
     proto::{HyparviewConfig, PlumtreeConfig},
 };
-use iroh_n0des::{API_SECRET_ENV_VAR_NAME, ApiSecret, caps::NetDiagnosticsCap};
+use iroh_services::{API_SECRET_ENV_VAR_NAME, ApiSecret, caps::NetDiagnosticsCap};
 use n0_future::task::AbortOnDropHandle;
 pub use p2p_model_sharing::{
     MODEL_REQUEST_TIMEOUT_SECS, ModelConfigSharingMessage, ParameterSharingMessage,
@@ -192,7 +192,7 @@ where
     metrics: Arc<ClientMetrics>,
     endpoint: Endpoint,
     connection_monitor: ConnectionMonitor,
-    _iroh_n0des_client: Option<iroh_n0des::Client>,
+    _iroh_services_client: Option<iroh_services::Client>,
     _iroh_diagnostics_task: Option<AbortOnDropHandle<()>>,
 }
 
@@ -395,8 +395,8 @@ where
 
         info!("Our endpoint ID: {}", endpoint_addr.id);
 
-        let iroh_n0des_client = {
-            let builder = iroh_n0des::Client::builder(&endpoint);
+        let iroh_services_client = {
+            let builder = iroh_services::Client::builder(&endpoint);
             let allowlist = allowlist.clone();
 
             (async move {
@@ -422,7 +422,7 @@ where
 
                 Ok(client)
             })
-            .await as anyhow::Result<iroh_n0des::Client>
+            .await as anyhow::Result<iroh_services::Client>
         }
         .map_or_else(
             |e| {
@@ -479,13 +479,13 @@ where
             endpoint.clone(),
             SupportedProtocols::new(gossip.clone(), blobs_protocol, model_parameter_sharing),
             additional_protocol,
-            iroh_n0des_client
+            iroh_services_client
                 .as_ref()
-                .map(|_| iroh_n0des::ClientHost::new(&endpoint)),
+                .map(|_| iroh_services::ClientHost::new(&endpoint)),
         )?;
         trace!("router created!");
 
-        let iroh_diagnostics_task = iroh_n0des_client
+        let iroh_diagnostics_task = iroh_services_client
             .as_ref()
             .map(|client| spawn_network_diagnostics_loop(client.clone()));
 
@@ -516,7 +516,7 @@ where
             _download: Default::default(),
             endpoint,
             connection_monitor,
-            _iroh_n0des_client: iroh_n0des_client,
+            _iroh_services_client: iroh_services_client,
             _iroh_diagnostics_task: iroh_diagnostics_task,
         })
     }
@@ -961,7 +961,7 @@ fn hash_bytes(bytes: &Bytes) -> u64 {
     hasher.finish()
 }
 
-fn spawn_network_diagnostics_loop(client: iroh_n0des::Client) -> AbortOnDropHandle<()> {
+fn spawn_network_diagnostics_loop(client: iroh_services::Client) -> AbortOnDropHandle<()> {
     AbortOnDropHandle::new(tokio::spawn(async move {
         let mut diagnostics_interval = tokio::time::interval(Duration::from_secs(60 * 60));
         diagnostics_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);

--- a/shared/network/src/router.rs
+++ b/shared/network/src/router.rs
@@ -27,7 +27,7 @@ pub(crate) fn spawn_router<P: ProtocolHandler + Clone>(
     endpoint: Endpoint,
     protocols: SupportedProtocols,
     additional_protocol: Option<(&'static [u8], P)>,
-    iroh_n0des_host: Option<iroh_n0des::ClientHost>,
+    iroh_services_host: Option<iroh_services::ClientHost>,
 ) -> Result<Arc<Router>> {
     let mut builder = Router::builder(endpoint.clone())
         .accept(iroh_gossip::ALPN, protocols.0)
@@ -39,8 +39,8 @@ pub(crate) fn spawn_router<P: ProtocolHandler + Clone>(
         builder = builder.accept(alpn, handler);
     }
 
-    if let Some(host) = iroh_n0des_host {
-        builder = builder.accept(iroh_n0des::CLIENT_HOST_ALPN, host);
+    if let Some(host) = iroh_services_host {
+        builder = builder.accept(iroh_services::CLIENT_HOST_ALPN, host);
     }
 
     let router = Arc::new(builder.spawn());


### PR DESCRIPTION
Closes #586

Adds the recently introduced `iroh-n0des` network diagnostic capabilities. This allows `n0des` to pull them directly from our nodes and should also provide us with better metrics.