### PR TITLE
Gateway auth

### DIFF
--- a/architectures/inference-only/inference-node/Cargo.toml
+++ b/architectures/inference-only/inference-node/Cargo.toml
@@ -42,6 +42,6 @@ uuid = { version = "1", features = ["v4"] }
 pyo3.workspace = true
 postcard.workspace = true
 axum = { version = "0.7", features = ["macros"] }
-tower = { version = "0.4" }
+tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.5", features = ["cors"] }
 tikv-jemallocator.workspace = true


### PR DESCRIPTION
Running expensive services with no auth on the public internet scares me, so I got ol' mate Claude to add a basic auth system to the inference, then add some unit tests to ensure it's all good.

General idea:
- If the gateway is started with no secret, it'll run without auth (current behaviour)
- If the gateway is started with a secret, it'll verify if incoming inference requests include the secret in a bearer token

Pretty simple, but compatible with the OpenAI clients and it'll fit in trivially with the API service.